### PR TITLE
Fix：An error is reported when the browser exits

### DIFF
--- a/pydoll/browser/managers.py
+++ b/pydoll/browser/managers.py
@@ -1,7 +1,10 @@
+import inspect
 import os
 import shutil
 import subprocess
-from contextlib import suppress
+import time
+from functools import partial
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from pydoll.browser.constants import BrowserType
@@ -207,6 +210,11 @@ class TempDirectoryManager:
             temp_dir_factory (callable, optional): A function that creates
                 temporary directories. Defaults to TemporaryDirectory.
         """
+        sig = inspect.signature(temp_dir_factory)
+        if 'prefix' in sig.parameters:
+            temp_dir_factory = partial(
+                temp_dir_factory, prefix='pydoll_chromium_profile-'
+            )
         self._temp_dir_factory = temp_dir_factory
         self._temp_dirs = []
 
@@ -235,9 +243,54 @@ class TempDirectoryManager:
         Returns:
             None
         """
+
+        def retry_process_file(
+                func: callable,
+                path: str,
+                retry_times: int = 10
+        ):
+            """
+            Repeatedly attempts to execute a function until it succeeds or the
+             number of retries is exhausted.
+
+            Args:
+                func (callable): process function to execute.
+                path (str): The path of the temporary directory.:
+                retry_times (int): The number of times to retry the process.
+                    Defaults to 10.
+
+            Returns:
+
+            """
+            retry_time = 0
+            while retry_times < 0 or retry_time < retry_times:
+                retry_time += 1
+                try:
+                    func(path)
+                    break
+                except PermissionError:
+                    time.sleep(.1)
+            else:
+                raise PermissionError
+
+        def handle_error(func: callable, path: str, exc_info: tuple):
+            """Handles errors during directory removal."""
+            matches = ['CrashpadMetrics-active.pma']
+            exc_type, exc_value, _ = exc_info
+
+            if exc_type is PermissionError:
+                if Path(path).name in matches:
+                    try:
+                        retry_process_file(func, path)
+                        return
+                    except PermissionError:
+                        raise exc_value
+            elif exc_type is OSError:
+                return
+            raise exc_value
+
         for temp_dir in self._temp_dirs:
-            with suppress(OSError):
-                shutil.rmtree(temp_dir.name)
+            shutil.rmtree(temp_dir.name, onerror=handle_error)
 
 
 class BrowserOptionsManager:

--- a/pydoll/connection/connection.py
+++ b/pydoll/connection/connection.py
@@ -181,7 +181,10 @@ class ConnectionHandler:
         """
         await self.clear_callbacks()
         if self._ws_connection is not None:
-            await self._ws_connection.close()
+            try:
+                await self._ws_connection.close()
+            except websockets.ConnectionClosed as e:
+                logger.info(f'WebSocket connection has closed: {e}')
             logger.info('WebSocket connection closed.')
 
     async def _ensure_active_connection(self):

--- a/tests/test_browser_managers.py
+++ b/tests/test_browser_managers.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, ANY
 
 import pytest
 
@@ -105,8 +105,8 @@ def test_cleanup_temp_dirs(temp_manager):
         temp_manager.cleanup()
 
         assert mock_rmtree.call_count == 2
-        mock_rmtree.assert_any_call(mock_dir1.name)
-        mock_rmtree.assert_any_call(mock_dir2.name)
+        mock_rmtree.assert_any_call(mock_dir1.name, onerror=ANY)
+        mock_rmtree.assert_any_call(mock_dir2.name, onerror=ANY)
 
 
 def test_initialize_options_with_none():

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -149,6 +149,11 @@ async def test_close(connection_handler):
     connection_handler.clear_callbacks.assert_awaited_once()
     connection_handler._ws_connection.close.assert_awaited_once()
 
+    connection_handler._ws_connection.close.side_effect = websockets.ConnectionClosed(
+        1000, 'Normal Closure', rcvd_then_sent=True
+    )
+    await connection_handler.close()
+
 
 @pytest.mark.asyncio
 async def test_execute_command_connection_closed(connection_handler_closed):


### PR DESCRIPTION
# Bug Fix Pull Request

## Related Issue(s)
Fixes [#86](https://github.com/autoscrape-labs/pydoll/issues/86)

## Bug Description
I found that only on Windows. An error message is reported when the browser task is executed 


## Root Cause
- The `websockets.ConnectionClosed` exception is being thrown by await self._ws_connection.close() because the WebSocket connection is already closed when attempting to close it again.  
- After closing the browser by terminating the process, The file `CrashpadMetrics-active.pma` will be written.

## Solution
- The first problem was mitigated through proper exception handling of the `websockets.ConnectionClosed` error during WebSocket disconnection
- I have resolved the second issue by retry cleanup of the `CrashpadMetrics-active.pma` file

## Verification Steps
I'm not so sure, maybe just run code example on Windows? Because I've tested and verified this issue on 3 different Windows computers.

## Code Example
```python
import asyncio

from pydoll.browser.chrome import Chrome


async def main():
    async with Chrome() as browser:
        await browser.start()
        page = await browser.get_page()

        await page.go_to('https://www.google.com/')

asyncio.run(main())

```

## Before / After
### Before Code Error Traceback
```python
Traceback (most recent call last):
  File "D:\study\program\pydoll\pr\example.py", line 13, in <module>
    asyncio.run(main())
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "D:\study\program\pydoll\pr\example.py", line 7, in main
    async with Chrome() as browser:
  File "D:\study\program\pydoll\pydoll\browser\base.py", line 87, in __aexit__
    await self.stop()
  File "D:\study\program\pydoll\pydoll\browser\base.py", line 256, in stop
    await self._connection_handler.close()
  File "D:\study\program\pydoll\pydoll\connection\connection.py", line 184, in close
    await self._ws_connection.close()
  File "D:\study\program\pydoll\.venv\lib\site-packages\websockets\legacy\protocol.py", line 763, in close
    await self.write_close_frame(Close(code, reason))
  File "D:\study\program\pydoll\.venv\lib\site-packages\websockets\legacy\protocol.py", line 1224, in write_close_frame
    await self.write_frame(True, OP_CLOSE, data, _state=State.CLOSING)
  File "D:\study\program\pydoll\.venv\lib\site-packages\websockets\legacy\protocol.py", line 1199, in write_frame
    await self.drain()
  File "D:\study\program\pydoll\.venv\lib\site-packages\websockets\legacy\protocol.py", line 1188, in drain
    await self.ensure_open()
  File "D:\study\program\pydoll\.venv\lib\site-packages\websockets\legacy\protocol.py", line 929, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: sent 1000 (OK); no close frame received
Traceback (most recent call last):
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\shutil.py", line 618, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] 拒绝访问。: 'C:\\Users\\DELL\\AppData\\Local\\Temp\\tmpeid_zeue\\CrashpadMetrics-active.pma'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\tempfile.py", line 852, in onerror
    _os.unlink(path)
PermissionError: [WinError 5] 拒绝访问。: 'C:\\Users\\DELL\\AppData\\Local\\Temp\\tmpeid_zeue\\CrashpadMetrics-active.pma'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\weakref.py", line 667, in _exitfunc
    f()
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\weakref.py", line 591, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\tempfile.py", line 868, in _cleanup
    cls._rmtree(name, ignore_errors=ignore_errors)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\tempfile.py", line 864, in _rmtree
    _shutil.rmtree(name, onerror=onerror)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\shutil.py", line 750, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\shutil.py", line 620, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\tempfile.py", line 855, in onerror
    cls._rmtree(path, ignore_errors=ignore_errors)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\tempfile.py", line 864, in _rmtree
    _shutil.rmtree(name, onerror=onerror)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\shutil.py", line 750, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\shutil.py", line 601, in _rmtree_unsafe
    onerror(os.scandir, path, sys.exc_info())
  File "C:\Users\DELL\AppData\Roaming\uv\python\cpython-3.10.16-windows-x86_64-none\lib\shutil.py", line 598, in _rmtree_unsafe
    with os.scandir(path) as scandir_it:
NotADirectoryError: [WinError 267] 目录名称无效。: 'C:\\Users\\DELL\\AppData\\Local\\Temp\\tmpeid_zeue\\CrashpadMetrics-active.pma'
```
### After
no error

## Testing
modify function test_cleanup_temp_dirs in test_browser_managers:
- Add `test_handle_cleanup_error`
- Add `test_retry_process_file`
- Add args `onerror` for `shutil.rmtree`.
- Add test for `test_close` when websockets.ConnectionClosed

## Testing Checklist
- [x] Added regression test that would have caught this bug
- [x] Modified existing tests to account for this fix
- [x] All tests pass
- [x] Edge cases have been tested

## Impact
<!-- Describe any potential impact this fix might have on existing functionality -->
- [x] Low (isolated fix with no side effects)
- [ ] Medium (might affect closely related functionality)
- [ ] High (affects multiple areas or changes core behavior)

## Backwards Compatibility
- [x] This change is fully backward compatible
- [ ] This change introduces backward incompatibilities (explain below)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added test cases that prove my fix is effective
- [x] I have run `poetry run task lint` and fixed any issues
- [x] I have run `poetry run task test` and all tests pass
- [x] My commits follow the [conventional commits](https://www.conventionalcommits.org/) style with message explaining the fix 