### PR TITLE
Replace `bs4` with `beautifulsoup4` in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -244,21 +244,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "bs4"
-version = "0.0.2"
-description = "Dummy package for Beautiful Soup (beautifulsoup4)"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "bs4-0.0.2-py2.py3-none-any.whl", hash = "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc"},
-    {file = "bs4-0.0.2.tar.gz", hash = "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925"},
-]
-
-[package.dependencies]
-beautifulsoup4 = "*"
-
-[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1859,4 +1844,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "ca2aad7a2be010532bea53fedd96a7c04a62ba55e048e9298dbfe73bf5f7d773"
+content-hash = "cca410d111f0e5cf18c26d0b6dcff67fa79b7ac27f71bdd7c1d0ed68f6158d52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.10"
 websockets = "^13.1"
 aiohttp = "^3.9.5"
 aiofiles = "^23.2.1"
-bs4 = "^0.0.2"
+beautifulsoup4 = "^4.12.3"
 mkdocstrings = "^0.29.1"
 
 


### PR DESCRIPTION
## Description
Updated the dependency name in `pyproject.toml` from `bs4` to the correct package name `beautifulsoup4`, as [bs4](https://pypi.org/project/bs4/) is a dummy package. There is no version change to `beautifulsoup4`.

## Type of Change
- [x] Build or CI/CD related changes