### PR TITLE
Implement singleton pattern for Tab instances and add tab retrieval method

### DIFF
--- a/pydoll/browser/chromium/base.py
+++ b/pydoll/browser/chromium/base.py
@@ -215,9 +215,29 @@ class Browser(ABC):  # noqa: PLR0904
 
         Targets include pages, service workers, shared workers, and browser process.
         Useful for debugging and managing multiple tabs.
+
+        Returns:
+            List of TargetInfo objects.
         """
         response: GetTargetsResponse = await self._execute_command(TargetCommands.get_targets())
         return response['result']['targetInfos']
+
+    async def get_opened_tabs(self) -> list[Tab]:
+        """
+        Get all opened tabs that are not extensions and have the type 'page'
+
+        Returns:
+            List of Tab instances. The last tab is the most recent one.
+        """
+        targets = await self.get_targets()
+        valid_tab_targets = [
+            target for target in targets if target['type'] == 'page'
+            and 'extension' not in target['url']
+        ]
+        return [
+            Tab(self, self._connection_port, target['targetId']) for target
+            in reversed(valid_tab_targets)
+        ]
 
     async def set_download_path(self, path: str, browser_context_id: Optional[str] = None):
         """Set download directory path (convenience method for set_download_behavior)."""

--- a/pydoll/browser/tab.py
+++ b/pydoll/browser/tab.py
@@ -124,19 +124,21 @@ class Tab(FindElementsMixin):  # noqa: PLR0904
         if hasattr(self, '_initialized') and self._initialized:
             return
 
-        self._browser = browser
-        self._connection_port = connection_port
-        self._target_id = target_id
-        self._connection_handler = ConnectionHandler(connection_port, self._target_id)
-        self._page_events_enabled = False
-        self._network_events_enabled = False
-        self._fetch_events_enabled = False
-        self._dom_events_enabled = False
-        self._runtime_events_enabled = False
-        self._intercept_file_chooser_dialog_enabled = False
+        self._browser: 'Browser' = browser
+        self._connection_port: int = connection_port
+        self._target_id: str = target_id
+        self._connection_handler: ConnectionHandler = ConnectionHandler(
+            connection_port, self._target_id
+        )
+        self._page_events_enabled: bool = False
+        self._network_events_enabled: bool = False
+        self._fetch_events_enabled: bool = False
+        self._dom_events_enabled: bool = False
+        self._runtime_events_enabled: bool = False
+        self._intercept_file_chooser_dialog_enabled: bool = False
         self._cloudflare_captcha_callback_id: Optional[int] = None
-        self._browser_context_id = browser_context_id
-        self._initialized = True
+        self._browser_context_id: Optional[str] = browser_context_id
+        self._initialized: bool = True
 
     @classmethod
     def _remove_instance(cls, target_id: str) -> None:

--- a/pydoll/browser/tab.py
+++ b/pydoll/browser/tab.py
@@ -68,7 +68,42 @@ class Tab(FindElementsMixin):  # noqa: PLR0904
     Primary interface for web page automation including navigation, DOM manipulation,
     JavaScript execution, event handling, network monitoring, and specialized tasks
     like Cloudflare bypass.
+
+    This class implements a singleton pattern based on target_id to ensure
+    only one Tab instance exists per browser tab.
     """
+
+    _instances: dict[str, 'Tab'] = {}
+
+    def __new__(
+        cls,
+        browser: 'Browser',
+        connection_port: int,
+        target_id: str,
+        browser_context_id: Optional[str] = None,
+    ) -> 'Tab':
+        """
+        Create or return existing Tab instance for the given target_id.
+
+        Args:
+            browser: Browser instance that created this tab.
+            connection_port: CDP WebSocket port.
+            target_id: CDP target identifier for this tab.
+            browser_context_id: Optional browser context ID.
+
+        Returns:
+            Tab instance (new or existing) for the target_id.
+        """
+        if target_id in cls._instances:
+            existing_instance = cls._instances[target_id]
+            existing_instance._browser = browser
+            existing_instance._connection_port = connection_port
+            existing_instance._browser_context_id = browser_context_id
+            return existing_instance
+
+        instance = super().__new__(cls)
+        cls._instances[target_id] = instance
+        return instance
 
     def __init__(
         self,
@@ -86,6 +121,9 @@ class Tab(FindElementsMixin):  # noqa: PLR0904
             target_id: CDP target identifier for this tab.
             browser_context_id: Optional browser context ID.
         """
+        if hasattr(self, '_initialized') and self._initialized:
+            return
+
         self._browser = browser
         self._connection_port = connection_port
         self._target_id = target_id
@@ -98,6 +136,40 @@ class Tab(FindElementsMixin):  # noqa: PLR0904
         self._intercept_file_chooser_dialog_enabled = False
         self._cloudflare_captcha_callback_id: Optional[int] = None
         self._browser_context_id = browser_context_id
+        self._initialized = True
+
+    @classmethod
+    def _remove_instance(cls, target_id: str) -> None:
+        """
+        Remove instance from registry when tab is closed.
+
+        Args:
+            target_id: Target ID to remove from registry.
+        """
+        cls._instances.pop(target_id, None)
+
+    @classmethod
+    def get_instance(cls, target_id: str) -> Optional['Tab']:
+        """
+        Get existing Tab instance for target_id if it exists.
+
+        Args:
+            target_id: Target ID to look up.
+
+        Returns:
+            Existing Tab instance or None if not found.
+        """
+        return cls._instances.get(target_id)
+
+    @classmethod
+    def get_all_instances(cls) -> dict[str, 'Tab']:
+        """
+        Get all active Tab instances.
+
+        Returns:
+            Dictionary mapping target_id to Tab instances.
+        """
+        return cls._instances.copy()
 
     @property
     def page_events_enabled(self) -> bool:
@@ -283,7 +355,9 @@ class Tab(FindElementsMixin):  # noqa: PLR0904
         Note:
             Tab instance becomes invalid after calling this method.
         """
-        return await self._execute_command(PageCommands.close())
+        result = await self._execute_command(PageCommands.close())
+        self._remove_instance(self._target_id)
+        return result
 
     async def get_frame(self, frame: WebElement) -> IFrame:
         """

--- a/tests/test_browser/test_tab_singleton.py
+++ b/tests/test_browser/test_tab_singleton.py
@@ -1,0 +1,180 @@
+"""
+Tests for Tab singleton pattern based on target_id.
+"""
+
+import pytest
+from unittest.mock import Mock, AsyncMock
+
+from pydoll.browser.tab import Tab
+
+
+class TestTabSingleton:
+    """Tests for Tab singleton behavior."""
+
+    def setup_method(self):
+        """Clear instance registry before each test."""
+        Tab._instances.clear()
+
+    def teardown_method(self):
+        """Clear instance registry after each test."""
+        Tab._instances.clear()
+
+    def test_same_target_id_returns_same_instance(self):
+        """Test that same target_id returns the same instance."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id = "target-123"
+        browser_context_id = "context-456"
+
+        # Act
+        tab1 = Tab(browser, connection_port, target_id, browser_context_id)
+        tab2 = Tab(browser, connection_port, target_id, browser_context_id)
+
+        # Assert
+        assert tab1 is tab2
+        assert tab1._target_id == target_id
+        assert tab2._target_id == target_id
+
+    def test_different_target_ids_return_different_instances(self):
+        """Test that different target_ids return different instances."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id1 = "target-123"
+        target_id2 = "target-456"
+
+        # Act
+        tab1 = Tab(browser, connection_port, target_id1)
+        tab2 = Tab(browser, connection_port, target_id2)
+
+        # Assert
+        assert tab1 is not tab2
+        assert tab1._target_id == target_id1
+        assert tab2._target_id == target_id2
+
+    def test_get_instance_returns_existing_instance(self):
+        """Test that get_instance returns existing instance."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id = "target-123"
+
+        # Act
+        tab = Tab(browser, connection_port, target_id)
+        retrieved_tab = Tab.get_instance(target_id)
+
+        # Assert
+        assert retrieved_tab is tab
+
+    def test_get_instance_returns_none_for_nonexistent_target(self):
+        """Test that get_instance returns None for non-existent target_id."""
+        # Act
+        retrieved_tab = Tab.get_instance("nonexistent-target")
+
+        # Assert
+        assert retrieved_tab is None
+
+    def test_get_all_instances_returns_all_active_instances(self):
+        """Test that get_all_instances returns all active instances."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id1 = "target-123"
+        target_id2 = "target-456"
+
+        # Act
+        tab1 = Tab(browser, connection_port, target_id1)
+        tab2 = Tab(browser, connection_port, target_id2)
+        all_instances = Tab.get_all_instances()
+
+        # Assert
+        assert len(all_instances) == 2
+        assert all_instances[target_id1] is tab1
+        assert all_instances[target_id2] is tab2
+
+    def test_remove_instance_removes_from_registry(self):
+        """Test that _remove_instance removes instance from registry."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id = "target-123"
+
+        # Act
+        tab = Tab(browser, connection_port, target_id)
+        assert Tab.get_instance(target_id) is tab
+
+        Tab._remove_instance(target_id)
+        retrieved_tab = Tab.get_instance(target_id)
+
+        # Assert
+        assert retrieved_tab is None
+        assert len(Tab.get_all_instances()) == 0
+
+    @pytest.mark.asyncio
+    async def test_close_removes_instance_from_registry(self):
+        """Test that close() removes instance from registry."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id = "target-123"
+        
+        tab = Tab(browser, connection_port, target_id)
+        tab._execute_command = AsyncMock(return_value={'result': 'success'})
+
+        # Verify instance is in registry
+        assert Tab.get_instance(target_id) is tab
+
+        # Act
+        await tab.close()
+
+        # Assert
+        assert Tab.get_instance(target_id) is None
+        assert len(Tab.get_all_instances()) == 0
+
+    def test_existing_instance_properties_are_updated(self):
+        """Test that existing instance properties are updated."""
+        # Arrange
+        browser1 = Mock()
+        browser2 = Mock()
+        connection_port1 = 9222
+        connection_port2 = 9223
+        target_id = "target-123"
+        context1 = "context-1"
+        context2 = "context-2"
+
+        # Act
+        tab1 = Tab(browser1, connection_port1, target_id, context1)
+        tab2 = Tab(browser2, connection_port2, target_id, context2)
+
+        # Assert
+        assert tab1 is tab2
+        assert tab1._browser is browser2  # Updated
+        assert tab1._connection_port == connection_port2  # Updated
+        assert tab1._browser_context_id == context2  # Updated
+
+    def test_initialization_is_skipped_for_existing_instance(self):
+        """Test that __init__ is skipped for existing instances."""
+        # Arrange
+        browser = Mock()
+        connection_port = 9222
+        target_id = "target-123"
+
+        # Act
+        tab1 = Tab(browser, connection_port, target_id)
+        original_initialized = tab1._initialized
+        
+        # Modify a property to verify __init__ is not executed again
+        tab1._page_events_enabled = True
+        
+        tab2 = Tab(browser, connection_port, target_id)
+
+        # Assert
+        assert tab1 is tab2
+        assert tab1._initialized == original_initialized
+        assert tab1._page_events_enabled is True  # Not reset
+
+    def test_remove_nonexistent_instance_does_not_raise_error(self):
+        """Test that removing non-existent instance does not raise error."""
+        # Act & Assert - should not raise exception
+        Tab._remove_instance("nonexistent-target") 


### PR DESCRIPTION
Introduce a method to retrieve non-extension opened tabs as Tab instances. Refactor Tab class to implement a singleton pattern based on target_id, ensuring only one instance per tab. Update documentation to include details on multi-tab management and the benefits of the singleton pattern.