### PR TITLE
fix: use correct class name and id selector in query()

### DIFF
--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 from pydoll.commands import (
@@ -352,18 +351,11 @@ class FindElementsMixin:
         Auto-detect selector type from expression syntax.
 
         Patterns:
-        - XPath: starts with //, .// , ./, or /
-        - ID: starts with #
-        - Class: starts with . (but not ./)
+        - XPath: starts with ./, or /
         - Default: CSS_SELECTOR
         """
-        xpath_pattern = r'^(//|\.//|\.\/|/)'
-        if re.match(xpath_pattern, expression):
+        if expression.startswith('./') or expression.startswith('/'):
             return By.XPATH
-        if expression.startswith('#'):
-            return By.ID
-        if expression.startswith('.') and not expression.startswith('./'):
-            return By.CLASS_NAME
 
         return By.CSS_SELECTOR
 
@@ -435,7 +427,7 @@ class FindElementsMixin:
             case _:
                 selector = escaped_value
         if object_id and not by == By.XPATH:
-            script = Scripts.RELATIVE_QUERY_SELECTOR_ALL.replace('{selector}', escaped_value)
+            script = Scripts.RELATIVE_QUERY_SELECTOR_ALL.replace('{selector}', selector)
             command = RuntimeCommands.call_function_on(
                 function_declaration=script,
                 object_id=object_id,

--- a/tests/test_find_elements_mixin.py
+++ b/tests/test_find_elements_mixin.py
@@ -168,19 +168,6 @@ class TestGetExpressionType:
         """Test XPath detection with single slash."""
         assert FindElementsMixin._get_expression_type('/html/body') == By.XPATH
 
-    def test_id_selector(self):
-        """Test ID selector detection."""
-        assert FindElementsMixin._get_expression_type('#main-content') == By.ID
-
-    def test_class_selector(self):
-        """Test class selector detection."""
-        assert FindElementsMixin._get_expression_type('.btn-primary') == By.CLASS_NAME
-
-    def test_class_selector_not_xpath(self):
-        """Test that class selector doesn't conflict with XPath dot slash."""
-        assert FindElementsMixin._get_expression_type('.button') == By.CLASS_NAME
-        assert FindElementsMixin._get_expression_type('./button') == By.XPATH
-
     def test_css_selector_default(self):
         """Test CSS selector as default."""
         assert FindElementsMixin._get_expression_type('div.content > p') == By.CSS_SELECTOR
@@ -192,6 +179,11 @@ class TestGetExpressionType:
     def test_css_selector_pseudo_class(self):
         """Test CSS selector with pseudo-classes."""
         assert FindElementsMixin._get_expression_type('button:hover') == By.CSS_SELECTOR
+    
+    def test_css_selector_not_xpath(self):
+        """Test that css selector doesn't conflict with XPath dot slash."""
+        assert FindElementsMixin._get_expression_type('.button') == By.CSS_SELECTOR
+        assert FindElementsMixin._get_expression_type('./button') == By.XPATH
 
     def test_complex_xpath_expressions(self):
         """Test complex XPath expressions are detected correctly."""
@@ -208,12 +200,6 @@ class TestGetExpressionType:
         """Test edge case expressions."""
         # Empty string should default to CSS
         assert FindElementsMixin._get_expression_type('') == By.CSS_SELECTOR
-        
-        # Just a dot should be class selector
-        assert FindElementsMixin._get_expression_type('.') == By.CLASS_NAME
-        
-        # Just a hash should be ID selector
-        assert FindElementsMixin._get_expression_type('#') == By.ID
 
 
 class TestEnsureRelativeXPath:


### PR DESCRIPTION
# Bug Fix Pull Request

## Related Issue(s)
Fixes #186 

## Bug Description & Root Cause
When querying a class `.red`, `_get_expression_type()` returns `By.CLASS_NAME`. Then in `_get_find_elements_command()` it prepends a period resulting in `..red`. Thus, no results are returned.

## Solution
There are two ways to fix this bug.
1. Strip the preceding period and then use `By.CLASS_NAME`
2. Use `By.CSS_SELECTOR`

I opted to fix this using the latter option. This is because `query()` is analogous to `document.querySelector()`, and the selector could look like `.red[data-hover="green"]`. The current logic would try to use `By.CLASS_NAME` because of the preceding period which isn't really correct.

## Verification Steps
Fix works for the code example given in the original issue.

## Testing
The `_get_find_elements_command` isn't great for unit testing because it's doing two things. It's first doing the job of creating the selector (adding the preceding `.` or `#` and then escaping it) and then creating the command. I haven't added unit tests.

## Testing Checklist
- [ ] Added regression test that would have caught this bug
- [ ] Modified existing tests to account for this fix
- [x] All tests pass
- [ ] Edge cases have been tested

## Impact
<!-- Describe any potential impact this fix might have on existing functionality -->
- [x] Low (isolated fix with no side effects)
- [ ] Medium (might affect closely related functionality)
- [ ] High (affects multiple areas or changes core behavior)

## Backwards Compatibility
- [x] This change is fully backward compatible
- [ ] This change introduces backward incompatibilities (explain below)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added test cases that prove my fix is effective
- [x] I have run `poetry run task lint` and fixed any issues
- [x] I have run `poetry run task test` and all tests pass
- [x] My commits follow the [conventional commits](https://www.conventionalcommits.org/) style with message explaining the fix 