### PR TITLE
feat: add configurable page load state

### DIFF
--- a/pydoll/browser/interfaces.py
+++ b/pydoll/browser/interfaces.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from pydoll.constants import PageLoadState
+
 
 class Options(ABC):
     @property
@@ -34,6 +36,16 @@ class Options(ABC):
     @headless.setter
     @abstractmethod
     def headless(self, headless: bool):
+        pass
+
+    @property
+    @abstractmethod
+    def page_load_state(self) -> PageLoadState:
+        pass
+
+    @page_load_state.setter
+    @abstractmethod
+    def page_load_state(self, state: PageLoadState):
         pass
 
 

--- a/pydoll/browser/options.py
+++ b/pydoll/browser/options.py
@@ -1,6 +1,7 @@
 from contextlib import suppress
 
 from pydoll.browser.interfaces import Options
+from pydoll.constants import PageLoadState
 from pydoll.exceptions import (
     ArgumentAlreadyExistsInOptions,
     ArgumentNotFoundInOptions,
@@ -28,6 +29,7 @@ class ChromiumOptions(Options):
         self._start_timeout = 10
         self._browser_preferences = {}
         self._headless = False
+        self._page_load_state = PageLoadState.COMPLETE
 
     @property
     def arguments(self) -> list[str]:
@@ -316,3 +318,11 @@ class ChromiumOptions(Options):
         if headless == has_argument:
             return
         methods_map[headless]('--headless')
+
+    @property
+    def page_load_state(self) -> PageLoadState:
+        return self._page_load_state
+
+    @page_load_state.setter
+    def page_load_state(self, state: PageLoadState):
+        self._page_load_state = state

--- a/pydoll/browser/tab.py
+++ b/pydoll/browser/tab.py
@@ -1065,7 +1065,10 @@ class Tab(FindElementsMixin):
             response: EvaluateResponse = await self._execute_command(
                 RuntimeCommands.evaluate(expression='document.readyState')
             )
-            if response['result']['result']['value'] == 'complete':
+            if (
+                response['result']['result']['value']
+                == self._browser.options.page_load_state.value
+            ):
                 break
             if asyncio.get_event_loop().time() - start_time > timeout:
                 raise WaitElementTimeout('Page load timed out')

--- a/pydoll/constants.py
+++ b/pydoll/constants.py
@@ -10,6 +10,11 @@ class By(str, Enum):
     NAME = 'name'
 
 
+class PageLoadState(str, Enum):
+    COMPLETE = 'complete'
+    INTERACTIVE = 'interactive'
+
+
 class Scripts:
     ELEMENT_VISIBLE = """
     function() {

--- a/tests/test_browser/test_browser_options.py
+++ b/tests/test_browser/test_browser_options.py
@@ -2,6 +2,7 @@ import pytest
 
 from pydoll.browser.interfaces import Options as OptionsInterface
 from pydoll.browser.options import ChromiumOptions as Options
+from pydoll.constants import PageLoadState
 from pydoll.exceptions import (
     ArgumentAlreadyExistsInOptions,
     ArgumentNotFoundInOptions,
@@ -29,6 +30,17 @@ def test_set_start_timeout():
     options = Options()
     options.start_timeout = 30
     assert options.start_timeout == 30
+
+
+def test_initial_page_load_state():
+    options = Options()
+    assert options.page_load_state == PageLoadState.COMPLETE
+
+
+def test_set_page_load_state():
+    options = Options()
+    options.page_load_state = PageLoadState.INTERACTIVE
+    assert options.page_load_state == PageLoadState.INTERACTIVE
 
 
 def test_add_argument():
@@ -224,6 +236,14 @@ def test_options_interface_enforcement():
         @property
         def headless(self):
             return False
+
+        @property
+        def page_load_state(self):
+            return PageLoadState.COMPLETE
+
+        @page_load_state.setter
+        def page_load_state(self, state):
+            pass
 
     CompleteOptions()
 


### PR DESCRIPTION
## Summary
- add `PageLoadState` enum for document readiness
- allow configuring `page_load_state` via Options and wait loop
- cover new option with tests

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_browser/test_browser_options.py`
- `PYENV_VERSION=3.11.12 pytest` *(fails: No module named 'aioresponses')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7795b1b083208903f71dbb55c70c