### PR TITLE
fix(elements): correctly detect parenthesized XPath expressions

### DIFF
--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -478,7 +478,7 @@ class FindElementsMixin:
         - XPath: starts with ./, or /
         - Default: CSS_SELECTOR
         """
-        if any([expression.startswith('./'), expression.startswith('/'), expression.startswith('(/')]):
+        if expression.startswith(('./', '/', '(/')):
             return By.XPATH
 
         return By.CSS_SELECTOR

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -478,7 +478,7 @@ class FindElementsMixin:
         - XPath: starts with ./, or /
         - Default: CSS_SELECTOR
         """
-        if expression.startswith('./') or expression.startswith('/') or expression.startswith('(/'):
+        if any([expression.startswith('./'), expression.startswith('/'), expression.startswith('(/')]):
             return By.XPATH
 
         return By.CSS_SELECTOR

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -478,7 +478,7 @@ class FindElementsMixin:
         - XPath: starts with ./, or /
         - Default: CSS_SELECTOR
         """
-        if expression.startswith('./') or expression.startswith('/'):
+        if expression.startswith('./') or expression.startswith('/') or expression.startswith('(/'):
             return By.XPATH
 
         return By.CSS_SELECTOR

--- a/tests/test_find_elements_mixin.py
+++ b/tests/test_find_elements_mixin.py
@@ -201,6 +201,16 @@ class TestGetExpressionType:
         # Empty string should default to CSS
         assert FindElementsMixin._get_expression_type('') == By.CSS_SELECTOR
 
+    def test_xpath_with_parentheses_and_predicate(self):
+        """Test XPath detection with parentheses, e.g. (//div)[last()]."""
+        expressions = [
+            '(//div)[last()]',
+            '(//span[@class="btn"])[1]',
+            '(/html/body/div)[position()=1]'
+        ]
+        for expr in expressions:
+            assert FindElementsMixin._get_expression_type(expr) == By.XPATH
+
 
 class TestEnsureRelativeXPath:
     """Test the _ensure_relative_xpath static method."""


### PR DESCRIPTION
# Bug Fix _get_expression_type

## Related Issue(s)
N/A

## Bug Description
XPath expressions wrapped in parentheses (e.g. `(//div)[last()]`) were incorrectly detected as CSS selectors instead of XPath.

## Root Cause
The `_get_expression_type` method only checked for prefixes like `//`, `.//`, `./`, or `/`, but not for parenthesized XPath expressions starting with `"(/"`.

## Solution
Extended `_get_expression_type` to treat expressions starting with `"(/"` as XPath.  
Added regression tests for expressions such as `(//div)[last()]` and similar variations.

## Verification Steps
1. Run `poetry run pytest -k "test_xpath_with_parentheses_and_predicate or test_get_expression_type"` and confirm all tests pass.  
2. Ensure new tests in `TestGetExpressionType` for parenthesized XPaths pass.  
3. Confirm no regressions in existing selector detection.

## Code Example
```python
# Before: misclassified as CSS
FindElementsMixin._get_expression_type('(//div)[last()]')  # -> By.CSS_SELECTOR ❌

# After: correctly detected as XPath
FindElementsMixin._get_expression_type('(//div)[last()]')  # -> By.XPATH ✅
