### PR TITLE
feat: implement User-Agent override propagation to worker contexts

### DIFF
--- a/pydoll/browser/chromium/base.py
+++ b/pydoll/browser/chromium/base.py
@@ -40,7 +40,9 @@ from pydoll.exceptions import (
 from pydoll.protocol.browser.types import DownloadBehavior
 from pydoll.protocol.fetch.events import FetchEvent
 from pydoll.protocol.fetch.types import AuthChallengeResponseType
-from pydoll.utils.user_agent_parser import UserAgentParser
+from pydoll.protocol.target.events import TargetEvent
+from pydoll.protocol.target.types import FilterEntry
+from pydoll.utils.user_agent_parser import ParsedUserAgent, UserAgentParser
 
 if TYPE_CHECKING:
     from tempfile import TemporaryDirectory
@@ -196,6 +198,7 @@ class Browser(ABC):  # noqa: PLR0904
         valid_tab_id = await self._get_valid_tab_id(await self.get_targets())
         tab = Tab(self, target_id=valid_tab_id, connection_port=self._connection_port)
         self._tabs_opened[valid_tab_id] = tab
+        await self._setup_worker_user_agent_override()
         await self._apply_user_agent_override(tab)
         logger.info(f'Initial tab attached: {valid_tab_id}')
         return tab
@@ -791,6 +794,90 @@ class Browser(ABC):  # noqa: PLR0904
                     run_immediately=True,
                 )
             )
+
+        await tab.on(
+            TargetEvent.ATTACHED_TO_TARGET,
+            self._build_worker_user_agent_handler(parsed, user_agent, tab._connection_handler),
+        )
+        await tab._execute_command(
+            TargetCommands.set_auto_attach(
+                auto_attach=True,
+                wait_for_debugger_on_start=True,
+                flatten=True,
+                filter=[FilterEntry(type='worker')],
+            )
+        )
+
+    async def _setup_worker_user_agent_override(self) -> None:
+        """Propagate the User-Agent override to out-of-page worker targets.
+
+        Emulation.setUserAgentOverride is scoped per target, so service and
+        shared workers (which live in the browser context, not the page) keep
+        the real navigator.platform and navigator.userAgentData unless the
+        override is reapplied to their own sessions. This auto-attaches to those
+        worker targets at browser level and replays the override before they run.
+        """
+        user_agent = self._get_user_agent_from_options()
+        if not user_agent:
+            return
+
+        parsed = UserAgentParser.parse(user_agent)
+        await self.on(
+            TargetEvent.ATTACHED_TO_TARGET,
+            self._build_worker_user_agent_handler(parsed, user_agent, self._connection_handler),
+        )
+        await self._execute_command(
+            TargetCommands.set_auto_attach(
+                auto_attach=True,
+                wait_for_debugger_on_start=True,
+                flatten=True,
+                filter=[FilterEntry(type='service_worker'), FilterEntry(type='shared_worker')],
+            )
+        )
+
+    @staticmethod
+    def _build_worker_user_agent_handler(
+        parsed: ParsedUserAgent,
+        user_agent: str,
+        connection_handler: ConnectionHandler,
+    ) -> Callable[[dict], Awaitable[None]]:
+        """Build an attachedToTarget handler that replays the UA override on workers.
+
+        The returned coroutine applies Emulation.setUserAgentOverride to each
+        attached worker session and always resumes targets paused via
+        waitForDebuggerOnStart, so a worker never hangs on attach.
+        """
+        worker_types = {'service_worker', 'shared_worker', 'worker'}
+
+        async def on_worker_attached(event: dict) -> None:
+            params = event['params']
+            session_id = params['sessionId']
+            target_type = params['targetInfo']['type']
+            try:
+                if target_type in worker_types:
+                    override = EmulationCommands.set_user_agent_override(
+                        user_agent=user_agent,
+                        platform=parsed.platform,
+                        user_agent_metadata=parsed.user_agent_metadata,
+                    )
+                    override['sessionId'] = session_id
+                    await connection_handler.execute_command(override)
+                    if parsed.navigator_override_js:
+                        inject = RuntimeCommands.evaluate(expression=parsed.navigator_override_js)
+                        inject['sessionId'] = session_id
+                        await connection_handler.execute_command(inject)
+            except Exception:
+                logger.exception(
+                    'Failed to apply User-Agent override to worker session %s', session_id
+                )
+            finally:
+                if params.get('waitingForDebugger'):
+                    resume = RuntimeCommands.run_if_waiting_for_debugger()
+                    resume['sessionId'] = session_id
+                    with suppress(Exception):
+                        await connection_handler.execute_command(resume)
+
+        return on_worker_attached
 
     def _get_user_agent_from_options(self) -> Optional[str]:
         """Extract User-Agent value from --user-agent= browser argument."""

--- a/pydoll/commands/runtime_commands.py
+++ b/pydoll/commands/runtime_commands.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
         ReleaseObjectCommand,
         ReleaseObjectGroupCommand,
         RemoveBindingCommand,
+        RunIfWaitingForDebuggerCommand,
         RunScriptCommand,
         SerializationOptions,
         SetAsyncCallStackDepthCommand,
@@ -222,6 +223,19 @@ class RuntimeCommands:
             EnableCommand: Command object to enable the runtime domain.
         """
         return Command(method=RuntimeMethod.ENABLE)
+
+    @staticmethod
+    def run_if_waiting_for_debugger() -> RunIfWaitingForDebuggerCommand:
+        """
+        Resumes a target that was paused on start via waitForDebuggerOnStart.
+
+        Used after auto-attaching to a worker/service worker target so the
+        target can continue execution once overrides have been applied.
+
+        Returns:
+            RunIfWaitingForDebuggerCommand: Command to resume a paused target.
+        """
+        return Command(method=RuntimeMethod.RUN_IF_WAITING_FOR_DEBUGGER)
 
     @staticmethod
     def evaluate(  # noqa: PLR0912

--- a/pydoll/utils/user_agent_parser.py
+++ b/pydoll/utils/user_agent_parser.py
@@ -127,13 +127,16 @@ class UserAgentParser:
         )
         vendor = 'Google Inc.'
         app_version = UserAgentParser._build_app_version(user_agent)
+        platform = _PLATFORM_MAP.get(os_key, 'Win32')
 
         return ParsedUserAgent(
-            platform=_PLATFORM_MAP.get(os_key, 'Win32'),
+            platform=platform,
             vendor=vendor,
             app_version=app_version,
             user_agent_metadata=metadata,
-            navigator_override_js=UserAgentParser._build_navigator_override_js(vendor, app_version),
+            navigator_override_js=UserAgentParser._build_navigator_override_js(
+                vendor, app_version, platform
+            ),
         )
 
     @staticmethod
@@ -278,12 +281,27 @@ class UserAgentParser:
         return ''
 
     @staticmethod
-    def _build_navigator_override_js(vendor: str, app_version: str) -> str:
-        safe_vendor = vendor.replace("'", "\\'")
-        safe_app_version = app_version.replace('\\', '\\\\').replace("'", "\\'")
-        return (
-            "Object.defineProperty(Navigator.prototype, 'vendor', "
-            f"{{get: () => '{safe_vendor}'}});\n"
-            "Object.defineProperty(Navigator.prototype, 'appVersion', "
-            f"{{get: () => '{safe_app_version}'}});"
-        )
+    def _build_navigator_override_js(vendor: str, app_version: str, platform: str) -> str:
+        """Build JS aligning navigator properties with the spoofed User-Agent.
+
+        Reads the prototype via Object.getPrototypeOf(navigator) so the same
+        script works in both the page (Navigator) and worker (WorkerNavigator)
+        scopes, and only redefines properties that already exist to avoid
+        introducing anomalies such as navigator.vendor on WorkerNavigator,
+        which does not expose it.
+        """
+        overrides = {
+            'vendor': vendor,
+            'appVersion': app_version,
+            'platform': platform,
+        }
+        lines = ['(function () {', '  var proto = Object.getPrototypeOf(navigator);']
+        for prop, value in overrides.items():
+            safe_value = value.replace('\\', '\\\\').replace("'", "\\'")
+            lines.append(
+                f"  try {{ if ('{prop}' in navigator) {{ Object.defineProperty(proto, "
+                f"'{prop}', {{get: function () {{ return '{safe_value}'; }}, "
+                f'configurable: true}}); }} }} catch (e) {{}}'
+            )
+        lines.append('})();')
+        return '\n'.join(lines)

--- a/tests/pages/worker_ua/dedicated_worker.js
+++ b/tests/pages/worker_ua/dedicated_worker.js
@@ -1,0 +1,8 @@
+self.onmessage = function () {
+  const uaData = self.navigator.userAgentData;
+  self.postMessage({
+    platform: self.navigator.platform,
+    uaDataPlatform: uaData ? uaData.platform : null,
+    userAgent: self.navigator.userAgent,
+  });
+};

--- a/tests/pages/worker_ua/main.html
+++ b/tests/pages/worker_ua/main.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Worker User-Agent Override Test</title>
+  </head>
+  <body>
+    <h1 id="status">loading</h1>
+    <script>
+      window.__dedicatedResult = null;
+      window.__serviceWorkerResult = null;
+
+      function startDedicatedWorker() {
+        const worker = new Worker('dedicated_worker.js');
+        worker.onmessage = function (event) {
+          window.__dedicatedResult = event.data;
+        };
+        worker.postMessage('report');
+      }
+
+      async function startServiceWorker() {
+        const registration = await navigator.serviceWorker.register('service_worker.js');
+        await navigator.serviceWorker.ready;
+        const worker = registration.active;
+        const channel = new MessageChannel();
+        channel.port1.onmessage = function (event) {
+          window.__serviceWorkerResult = event.data;
+        };
+        worker.postMessage('report', [channel.port2]);
+      }
+
+      startDedicatedWorker();
+      startServiceWorker();
+      document.getElementById('status').textContent = 'ready';
+    </script>
+  </body>
+</html>

--- a/tests/pages/worker_ua/service_worker.js
+++ b/tests/pages/worker_ua/service_worker.js
@@ -1,0 +1,19 @@
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', function (event) {
+  const uaData = self.navigator.userAgentData;
+  const payload = {
+    platform: self.navigator.platform,
+    uaDataPlatform: uaData ? uaData.platform : null,
+    userAgent: self.navigator.userAgent,
+  };
+  if (event.ports && event.ports[0]) {
+    event.ports[0].postMessage(payload);
+  }
+});

--- a/tests/test_browser/test_browser_base.py
+++ b/tests/test_browser/test_browser_base.py
@@ -32,6 +32,7 @@ from pydoll.exceptions import (
 
 from pydoll.protocol.network.types import RequestMethod, ErrorReason
 from pydoll.protocol.browser.types import DownloadBehavior, PermissionType
+from pydoll.utils.user_agent_parser import UserAgentParser
 
 class ConcreteBrowser(Browser):
     def _get_default_binary_location(self) -> str:
@@ -1431,10 +1432,12 @@ async def test_apply_user_agent_override_with_ua_set(mock_browser):
 
     tab = MagicMock(spec=Tab)
     tab._execute_command = AsyncMock()
+    tab.on = AsyncMock()
+    tab._connection_handler = MagicMock()
 
     await mock_browser._apply_user_agent_override(tab)
 
-    assert tab._execute_command.call_count == 2
+    assert tab._execute_command.call_count == 3
 
     emulation_call = tab._execute_command.call_args_list[0]
     command = emulation_call[0][0]
@@ -1446,8 +1449,18 @@ async def test_apply_user_agent_override_with_ua_set(mock_browser):
     js_call = tab._execute_command.call_args_list[1]
     js_command = js_call[0][0]
     assert js_command['method'] == 'Page.addScriptToEvaluateOnNewDocument'
-    assert "Navigator.prototype, 'vendor'" in js_command['params']['source']
-    assert "Navigator.prototype, 'appVersion'" in js_command['params']['source']
+    assert 'Object.getPrototypeOf(navigator)' in js_command['params']['source']
+    assert "'vendor'" in js_command['params']['source']
+    assert "'appVersion'" in js_command['params']['source']
+    assert "'platform'" in js_command['params']['source']
+
+    auto_attach_call = tab._execute_command.call_args_list[2]
+    auto_attach_command = auto_attach_call[0][0]
+    assert auto_attach_command['method'] == 'Target.setAutoAttach'
+    assert auto_attach_command['params']['autoAttach'] is True
+    assert auto_attach_command['params']['filter'] == [{'type': 'worker'}]
+    tab.on.assert_awaited_once()
+    assert tab.on.call_args[0][0] == 'Target.attachedToTarget'
 
 
 @pytest.mark.asyncio
@@ -1461,6 +1474,8 @@ async def test_apply_user_agent_override_metadata_consistency(mock_browser):
 
     tab = MagicMock(spec=Tab)
     tab._execute_command = AsyncMock()
+    tab.on = AsyncMock()
+    tab._connection_handler = MagicMock()
 
     await mock_browser._apply_user_agent_override(tab)
 
@@ -1474,6 +1489,135 @@ async def test_apply_user_agent_override_metadata_consistency(mock_browser):
     brand_names = [b['brand'] for b in brands]
     assert 'Chromium' in brand_names
     assert 'Google Chrome' in brand_names
+
+
+@pytest.mark.asyncio
+async def test_setup_worker_user_agent_override_no_ua(mock_browser):
+    await mock_browser._setup_worker_user_agent_override()
+
+    mock_browser._connection_handler.register_callback.assert_not_called()
+    mock_browser._connection_handler.execute_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_worker_user_agent_override_registers_browser_level(mock_browser):
+    custom_ua = (
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+        'Chrome/120.0.6099.109 Safari/537.36'
+    )
+    mock_browser.options.add_argument(f'--user-agent={custom_ua}')
+
+    await mock_browser._setup_worker_user_agent_override()
+
+    mock_browser._connection_handler.register_callback.assert_awaited_once()
+    assert (
+        mock_browser._connection_handler.register_callback.call_args[0][0]
+        == 'Target.attachedToTarget'
+    )
+
+    auto_attach_command = mock_browser._connection_handler.execute_command.call_args[0][0]
+    assert auto_attach_command['method'] == 'Target.setAutoAttach'
+    assert auto_attach_command['params']['autoAttach'] is True
+    assert auto_attach_command['params']['waitForDebuggerOnStart'] is True
+    assert auto_attach_command['params']['filter'] == [
+        {'type': 'service_worker'},
+        {'type': 'shared_worker'},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_worker_handler_overrides_injects_and_resumes(mock_browser):
+    custom_ua = (
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+        'Chrome/120.0.6099.109 Safari/537.36'
+    )
+    parsed = UserAgentParser.parse(custom_ua)
+    connection = MagicMock()
+    connection.execute_command = AsyncMock()
+
+    handler = Browser._build_worker_user_agent_handler(parsed, custom_ua, connection)
+    await handler({
+        'params': {
+            'sessionId': 'WORKER_SESSION',
+            'targetInfo': {'type': 'service_worker'},
+            'waitingForDebugger': True,
+        }
+    })
+
+    methods = [call[0][0]['method'] for call in connection.execute_command.call_args_list]
+    assert methods == [
+        'Emulation.setUserAgentOverride',
+        'Runtime.evaluate',
+        'Runtime.runIfWaitingForDebugger',
+    ]
+    for call in connection.execute_command.call_args_list:
+        assert call[0][0]['sessionId'] == 'WORKER_SESSION'
+
+
+@pytest.mark.asyncio
+async def test_worker_handler_skips_non_worker_but_resumes(mock_browser):
+    custom_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.6099.109 Safari/537.36'
+    parsed = UserAgentParser.parse(custom_ua)
+    connection = MagicMock()
+    connection.execute_command = AsyncMock()
+
+    handler = Browser._build_worker_user_agent_handler(parsed, custom_ua, connection)
+    await handler({
+        'params': {
+            'sessionId': 'IFRAME_SESSION',
+            'targetInfo': {'type': 'iframe'},
+            'waitingForDebugger': True,
+        }
+    })
+
+    methods = [call[0][0]['method'] for call in connection.execute_command.call_args_list]
+    assert methods == ['Runtime.runIfWaitingForDebugger']
+
+
+@pytest.mark.asyncio
+async def test_worker_handler_resumes_even_if_override_fails(mock_browser):
+    custom_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.6099.109 Safari/537.36'
+    parsed = UserAgentParser.parse(custom_ua)
+
+    def _fail_on_override(command, *args, **kwargs):
+        if command['method'] == 'Emulation.setUserAgentOverride':
+            raise RuntimeError('boom')
+        return {}
+
+    connection = MagicMock()
+    connection.execute_command = AsyncMock(side_effect=_fail_on_override)
+
+    handler = Browser._build_worker_user_agent_handler(parsed, custom_ua, connection)
+    await handler({
+        'params': {
+            'sessionId': 'WORKER_SESSION',
+            'targetInfo': {'type': 'worker'},
+            'waitingForDebugger': True,
+        }
+    })
+
+    methods = [call[0][0]['method'] for call in connection.execute_command.call_args_list]
+    assert 'Runtime.runIfWaitingForDebugger' in methods
+
+
+@pytest.mark.asyncio
+async def test_worker_handler_does_not_resume_when_not_waiting(mock_browser):
+    custom_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.6099.109 Safari/537.36'
+    parsed = UserAgentParser.parse(custom_ua)
+    connection = MagicMock()
+    connection.execute_command = AsyncMock()
+
+    handler = Browser._build_worker_user_agent_handler(parsed, custom_ua, connection)
+    await handler({
+        'params': {
+            'sessionId': 'WORKER_SESSION',
+            'targetInfo': {'type': 'service_worker'},
+            'waitingForDebugger': False,
+        }
+    })
+
+    methods = [call[0][0]['method'] for call in connection.execute_command.call_args_list]
+    assert methods == ['Emulation.setUserAgentOverride', 'Runtime.evaluate']
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_agent_parser.py
+++ b/tests/test_user_agent_parser.py
@@ -93,11 +93,20 @@ class TestChromeWindows:
 
     def test_navigator_js_contains_vendor(self):
         result = UserAgentParser.parse(CHROME_WINDOWS_UA)
-        assert "Navigator.prototype, 'vendor'" in result.navigator_override_js
+        assert "'vendor'" in result.navigator_override_js
 
     def test_navigator_js_contains_app_version(self):
         result = UserAgentParser.parse(CHROME_WINDOWS_UA)
-        assert "Navigator.prototype, 'appVersion'" in result.navigator_override_js
+        assert "'appVersion'" in result.navigator_override_js
+
+    def test_navigator_js_contains_platform(self):
+        result = UserAgentParser.parse(CHROME_WINDOWS_UA)
+        assert "'platform'" in result.navigator_override_js
+        assert result.platform in result.navigator_override_js
+
+    def test_navigator_js_uses_prototype_of_navigator(self):
+        result = UserAgentParser.parse(CHROME_WINDOWS_UA)
+        assert 'Object.getPrototypeOf(navigator)' in result.navigator_override_js
 
 
 # --- Chrome on macOS ---

--- a/tests/test_worker_user_agent_integration.py
+++ b/tests/test_worker_user_agent_integration.py
@@ -1,0 +1,115 @@
+"""Integration tests for User-Agent override propagation into worker contexts.
+
+A spoofed Windows User-Agent must be reflected not only in the page but also
+inside dedicated workers and service workers, which run in separate CDP targets.
+The discriminating signals are navigator.platform and navigator.userAgentData:
+without per-worker propagation they leak the real operating system, producing
+the inconsistency that bot detectors look for.
+
+Pages are served over loopback because both Service Worker registration and
+navigator.userAgentData require a secure context.
+"""
+
+import asyncio
+import http.server
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+
+from pydoll.browser.chromium import Chrome
+
+PAGES_DIR = Path(__file__).parent / 'pages' / 'worker_ua'
+
+SPOOFED_UA = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+)
+
+
+class _SilentHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+
+def _wait_for_server(host: str, port: int, timeout: float = 5.0) -> None:
+    """Block until the server at host:port accepts a TCP connection."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f'Server {host}:{port} not ready within {timeout}s')
+
+
+@pytest.fixture(scope='module')
+def worker_server():
+    """Serve the worker test pages over loopback (a secure context)."""
+
+    class _Handler(_SilentHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(PAGES_DIR), **kwargs)
+
+    server = http.server.HTTPServer(('127.0.0.1', 0), _Handler)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    _wait_for_server('127.0.0.1', port)
+
+    yield port
+
+    server.shutdown()
+
+
+async def _wait_for_worker_result(tab, expression: str, timeout: float = 15.0) -> dict:
+    """Poll a page global until the worker has reported its navigator snapshot."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        response = await tab.execute_script(f'return {expression}', return_by_value=True)
+        value = response['result']['result'].get('value')
+        if value:
+            return value
+        await asyncio.sleep(0.1)
+    raise AssertionError(f'Timed out waiting for {expression}')
+
+
+class TestWorkerUserAgentOverride:
+    """Spoofed User-Agent must reach worker contexts, not just the page."""
+
+    @pytest.mark.asyncio
+    async def test_dedicated_worker_inherits_spoofed_user_agent(
+        self, ci_chrome_options, worker_server
+    ):
+        ci_chrome_options.add_argument(f'--user-agent={SPOOFED_UA}')
+        url = f'http://127.0.0.1:{worker_server}/main.html'
+
+        async with Chrome(options=ci_chrome_options) as browser:
+            tab = await browser.start()
+            await tab.go_to(url)
+
+            result = await _wait_for_worker_result(tab, 'window.__dedicatedResult')
+
+            assert result['uaDataPlatform'] == 'Windows'
+            assert result['platform'] == 'Win32'
+            assert 'Windows NT 10.0' in result['userAgent']
+
+    @pytest.mark.asyncio
+    async def test_service_worker_inherits_spoofed_user_agent(
+        self, ci_chrome_options, worker_server
+    ):
+        ci_chrome_options.add_argument(f'--user-agent={SPOOFED_UA}')
+        url = f'http://127.0.0.1:{worker_server}/main.html'
+
+        async with Chrome(options=ci_chrome_options) as browser:
+            tab = await browser.start()
+            await tab.go_to(url)
+
+            result = await _wait_for_worker_result(tab, 'window.__serviceWorkerResult')
+
+            assert result['uaDataPlatform'] == 'Windows'
+            assert result['platform'] == 'Win32'
+            assert 'Windows NT 10.0' in result['userAgent']


### PR DESCRIPTION
Closes #412 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-agent overrides now propagate to Web Workers (dedicated, service, and shared workers).
  * Added support for Chrome DevTools Protocol debugger command functionality.

* **Improvements**
  * Enhanced user-agent parser with platform information alignment for better compatibility.

* **Tests**
  * Added comprehensive integration test coverage for worker user-agent propagation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autoscrape-labs/pydoll/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->