### PR TITLE
Fix: resource leaks, incorrect behavior, and deprecation warnings

### DIFF
--- a/examples/cloudflare_bypass.py
+++ b/examples/cloudflare_bypass.py
@@ -11,7 +11,7 @@ async def example_with_context_manager():
     """
     browser = Chrome()
     await browser.start()
-    page = await browser.get_page()
+    page = await browser.new_tab()
 
     print('Using context manager approach...')
     async with page.expect_and_bypass_cloudflare_captcha():
@@ -32,7 +32,7 @@ async def example_with_enable_disable():
     """
     browser = Chrome()
     await browser.start()
-    page = await browser.get_page()
+    page = await browser.new_tab()
 
     print('Using enable/disable approach...')
 

--- a/pydoll/browser/chromium/base.py
+++ b/pydoll/browser/chromium/base.py
@@ -361,11 +361,12 @@ class Browser(ABC):  # noqa: PLR0904
             for target in targets
             if target['type'] == 'page' and 'extension' not in target['url']
         ]
-        all_target_ids = [target['targetId'] for target in valid_tab_targets]
+        all_target_ids = {target['targetId'] for target in valid_tab_targets}
+        # Prune stale entries: close tabs whose IDs no longer appear in targets.
+        for stale_id in set(self._tabs_opened.keys()) - all_target_ids:
+            del self._tabs_opened[stale_id]
         existing_target_ids = list(self._tabs_opened.keys())
-        remaining_target_ids = [
-            target_id for target_id in all_target_ids if target_id not in existing_target_ids
-        ]
+        remaining_target_ids = list(all_target_ids - set(existing_target_ids))
         existing_tabs = [self._tabs_opened[target_id] for target_id in existing_target_ids]
         new_tabs = []
         for target_id in reversed(remaining_target_ids):

--- a/pydoll/browser/chromium/base.py
+++ b/pydoll/browser/chromium/base.py
@@ -136,10 +136,11 @@ class Browser(ABC):  # noqa: PLR0904
         if self._backup_preferences_dir:
             logger.debug(f'Restoring backup preferences directory: {self._backup_preferences_dir}')
             user_data_dir = self._get_user_data_dir()
-            shutil.copy2(
-                self._backup_preferences_dir,
-                os.path.join(user_data_dir, 'Default', 'Preferences'),
-            )
+            if user_data_dir:
+                shutil.copy2(
+                    self._backup_preferences_dir,
+                    os.path.join(user_data_dir, 'Default', 'Preferences'),
+                )
         if await self._is_browser_running(timeout=2):
             await self.stop()
 
@@ -165,6 +166,8 @@ class Browser(ABC):  # noqa: PLR0904
         await self._setup_ws_address(ws_address)
         tabs = await self.get_opened_tabs()
         logger.info(f'Connected. Tabs available: {len(tabs)}')
+        if not tabs:
+            raise NoValidTabFound('No tabs available on remote browser')
         return tabs[0]
 
     async def start(self, headless: bool = False) -> Tab:

--- a/pydoll/browser/tab.py
+++ b/pydoll/browser/tab.py
@@ -624,13 +624,13 @@ class Tab(FindElementsMixin):
         if not timeout:
             return await self._collect_all_shadow_roots(deep)
 
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         while True:
             shadow_roots = await self._collect_all_shadow_roots(deep)
             if shadow_roots:
                 return shadow_roots
 
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            if asyncio.get_running_loop().time() - start_time > timeout:
                 raise WaitElementTimeout(
                     f'Timed out after {timeout}s waiting for shadow roots in page'
                 )
@@ -701,24 +701,29 @@ class Tab(FindElementsMixin):
     async def _collect_oopif_shadow_roots(self) -> list[ShadowRoot]:
         """Discover shadow roots inside cross-origin iframes (OOPIFs)."""
         browser_handler = ConnectionHandler(connection_port=self._connection_port)
-        targets_response: GetTargetsResponse = await browser_handler.execute_command(
-            TargetCommands.get_targets()
-        )
+        try:
+            targets_response: GetTargetsResponse = await browser_handler.execute_command(
+                TargetCommands.get_targets()
+            )
 
-        target_infos = targets_response.get('result', {}).get('targetInfos', [])
-        iframe_targets = [t for t in target_infos if t.get('type') == 'iframe']
+            target_infos = targets_response.get('result', {}).get('targetInfos', [])
+            iframe_targets = [t for t in target_infos if t.get('type') == 'iframe']
 
-        if not iframe_targets:
-            logger.debug('No OOPIF targets found')
-            return []
+            if not iframe_targets:
+                logger.debug('No OOPIF targets found')
+                return []
 
-        shadow_roots: list[ShadowRoot] = []
-        for target in iframe_targets:
-            roots = await self._collect_shadow_roots_from_oopif_target(target, browser_handler)
-            shadow_roots.extend(roots)
+            shadow_roots: list[ShadowRoot] = []
+            for target in iframe_targets:
+                roots = await self._collect_shadow_roots_from_oopif_target(
+                    target, browser_handler
+                )
+                shadow_roots.extend(roots)
 
-        logger.debug(f'Found {len(shadow_roots)} shadow roots in OOPIFs')
-        return shadow_roots
+            logger.debug(f'Found {len(shadow_roots)} shadow roots in OOPIFs')
+            return shadow_roots
+        finally:
+            await browser_handler.close()
 
     async def _collect_shadow_roots_from_oopif_target(
         self,
@@ -1681,7 +1686,7 @@ class Tab(FindElementsMixin):
             _page_events_was_enabled = False
             await self.enable_page_events()
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         will_begin: asyncio.Future[bool] = loop.create_future()
         done: asyncio.Future[bool] = loop.create_future()
         state: dict[str, Any] = {
@@ -1983,7 +1988,7 @@ class Tab(FindElementsMixin):
             WaitElementTimeout: If no matching shadow root is found within
                 *timeout* seconds.
         """
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         while True:
             shadow_roots = await self.find_shadow_roots(deep=False)
             for sr in shadow_roots:
@@ -1991,7 +1996,7 @@ class Tab(FindElementsMixin):
                 if _CLOUDFLARE_CHALLENGE_DOMAIN in html:
                     return sr
 
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            if asyncio.get_running_loop().time() - start_time > timeout:
                 raise WaitElementTimeout(
                     f'Timed out after {timeout}s waiting for Cloudflare Turnstile shadow root'
                 )

--- a/pydoll/browser/tab.py
+++ b/pydoll/browser/tab.py
@@ -715,9 +715,7 @@ class Tab(FindElementsMixin):
 
             shadow_roots: list[ShadowRoot] = []
             for target in iframe_targets:
-                roots = await self._collect_shadow_roots_from_oopif_target(
-                    target, browser_handler
-                )
+                roots = await self._collect_shadow_roots_from_oopif_target(target, browser_handler)
                 shadow_roots.extend(roots)
 
             logger.debug(f'Found {len(shadow_roots)} shadow roots in OOPIFs')

--- a/pydoll/connection/connection_handler.py
+++ b/pydoll/connection/connection_handler.py
@@ -117,10 +117,10 @@ class ConnectionHandler:
                 f'Sending command: id={command.get("id")}, method={command.get("method")}, '
                 f'timeout={timeout}s'
             )
-            start = asyncio.get_event_loop().time()
+            start = asyncio.get_running_loop().time()
             await ws.send(command_str)
             response: str = await asyncio.wait_for(future, timeout)
-            elapsed = asyncio.get_event_loop().time() - start
+            elapsed = asyncio.get_running_loop().time() - start
             logger.debug(f'Command completed: id={command.get("id")} in {elapsed:.3f}s')
             return json.loads(response)
         except asyncio.TimeoutError:

--- a/pydoll/constants.py
+++ b/pydoll/constants.py
@@ -407,8 +407,17 @@ new Promise((resolve) => {{
         // Standard input/textarea
         if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
             el.focus();
-            let start = el.selectionStart;
-            let end = el.selectionEnd;
+            let start, end;
+            try {
+                start = el.selectionStart;
+                end = el.selectionEnd;
+            } catch (e) {
+                // Unsupported input type (number, email, range, etc.)
+                el.value += text;
+                el.dispatchEvent(new Event('input', { bubbles: true }));
+                el.dispatchEvent(new Event('change', { bubbles: true }));
+                return true;
+            }
             const hasSelection = start !== end;
             // When inserting empty text with no selection, select all first
             // so the field is cleared (matches user expectation for insertText('')).
@@ -422,7 +431,9 @@ new Promise((resolve) => {{
             const before = el.value.substring(0, start);
             const after = el.value.substring(end);
             el.value = before + text + after;
-            el.selectionStart = el.selectionEnd = start + text.length;
+            try {
+                el.selectionStart = el.selectionEnd = start + text.length;
+            } catch (e) {}
             el.dispatchEvent(new Event('input', { bubbles: true }));
             el.dispatchEvent(new Event('change', { bubbles: true }));
             return true;

--- a/pydoll/constants.py
+++ b/pydoll/constants.py
@@ -413,7 +413,7 @@ new Promise((resolve) => {{
                 end = el.selectionEnd;
             } catch (e) {
                 // Unsupported input type (number, email, range, etc.)
-                el.value += text;
+                el.value = text ? el.value + text : '';
                 el.dispatchEvent(new Event('input', { bubbles: true }));
                 el.dispatchEvent(new Event('change', { bubbles: true }));
                 return true;

--- a/pydoll/constants.py
+++ b/pydoll/constants.py
@@ -406,8 +406,19 @@ new Promise((resolve) => {{
 
         // Standard input/textarea
         if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
-            const start = el.selectionStart || el.value.length;
-            const end = el.selectionEnd || el.value.length;
+            el.focus();
+            let start = el.selectionStart;
+            let end = el.selectionEnd;
+            const hasSelection = start !== end;
+            // When inserting empty text with no selection, select all first
+            // so the field is cleared (matches user expectation for insertText('')).
+            if (!hasSelection && text === '') {
+                el.select();
+                start = 0;
+                end = el.value.length;
+            }
+            start = start ?? el.value.length;
+            end = end ?? el.value.length;
             const before = el.value.substring(0, start);
             const after = el.value.substring(end);
             el.value = before + text + after;

--- a/pydoll/decorators.py
+++ b/pydoll/decorators.py
@@ -88,7 +88,7 @@ def retry(
         exponential_backoff (bool): If True, increase the delay exponentially
 
     Usage:
-        @retry_on_exception(
+        @retry(
             max_retries=3,
             exceptions=[ValueError, TypeError],
             delay=1

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -334,7 +334,7 @@ class FindElementsMixin:
             return await self._find_across_iframes(segments, timeout, find_all, raise_exc)
 
         find_method = self._find_element if not find_all else self._find_elements
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
 
         if not timeout:
             logger.debug('No timeout specified; performing single attempt')
@@ -349,7 +349,7 @@ class FindElementsMixin:
                     logger.debug('Found 1 element within timeout window')
                 return element
 
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            if asyncio.get_running_loop().time() - start_time > timeout:
                 if raise_exc:
                     logger.error('Timeout while waiting for elements')
                     raise WaitElementTimeout(
@@ -387,7 +387,7 @@ class FindElementsMixin:
             ElementNotFound: If ``timeout=0``, nothing found, and ``raise_exc=True``.
             WaitElementTimeout: If timeout expires and ``raise_exc=True``.
         """
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         selector_repr = ' -> '.join(seg for _, seg in segments)
 
         while True:
@@ -400,7 +400,7 @@ class FindElementsMixin:
                     raise ElementNotFound(f'Element not found across iframes: {selector_repr}')
                 return [] if find_all else None
 
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            if asyncio.get_running_loop().time() - start_time > timeout:
                 if raise_exc:
                     raise WaitElementTimeout(
                         f'Timed out after {timeout}s waiting for element '

--- a/pydoll/elements/web_element.py
+++ b/pydoll/elements/web_element.py
@@ -238,7 +238,10 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
             return None
 
         resolver = self._get_iframe_resolver()
+        old_context = self._iframe_context
         self._iframe_context = await resolver.resolve()
+        if old_context is not None and old_context is not self._iframe_context:
+            await old_context.close()
         self._apply_routing_from_context()
         return self._iframe_context
 
@@ -299,14 +302,14 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
         if not timeout:
             return await self._get_shadow_root()
 
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         while True:
             try:
                 return await self._get_shadow_root()
             except ShadowRootNotFound:
                 pass
 
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            if asyncio.get_running_loop().time() - start_time > timeout:
                 raise WaitElementTimeout(
                     f'Timed out after {timeout}s waiting for shadow root on element'
                 )
@@ -512,7 +515,7 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
             f'Waiting for element: visible={is_visible}, '
             f'interactable={is_interactable}, timeout={timeout}s'
         )
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         start_time = loop.time()
         while True:
             results = await asyncio.gather(*(check() for check in checks))
@@ -683,9 +686,18 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
         # Keep cached attributes coherent for common cases (e.g., input value)
         # This avoids forcing a DOM round-trip for simple assertions.
         if self._attributes.get('tag_name', '').lower() in {'input', 'textarea'}:
-            # When inserting into an empty field, resulting value equals inserted text.
-            # For complex cases (non-empty with caret), tests usually check non-empty.
-            self._attributes['value'] = text
+            # Re-read the actual DOM value to keep cache consistent.
+            # insertText appends at cursor, so the result may differ from
+            # the inserted text when the field already had content.
+            try:
+                live_result = await self.execute_script(
+                    'return this.value', return_by_value=True
+                )
+                self._attributes['value'] = (
+                    live_result.get('result', {}).get('result', {}).get('value', text)
+                )
+            except Exception:
+                self._attributes['value'] = text
 
     async def set_input_files(self, files: str | Path | list[str | Path]):
         """

--- a/pydoll/elements/web_element.py
+++ b/pydoll/elements/web_element.py
@@ -23,6 +23,7 @@ from pydoll.constants import (
 from pydoll.elements.mixins import FindElementsMixin
 from pydoll.elements.shadow_root import ShadowRoot
 from pydoll.exceptions import (
+    CommandExecutionTimeout,
     ElementNotAFileInput,
     ElementNotFound,
     ElementNotInteractable,
@@ -32,6 +33,7 @@ from pydoll.exceptions import (
     MissingScreenshotPath,
     ShadowRootNotFound,
     WaitElementTimeout,
+    WebSocketConnectionClosed,
 )
 from pydoll.interactions.iframe import IFrameContext, IFrameContextResolver
 from pydoll.interactions.keyboard import Keyboard
@@ -694,7 +696,13 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
                 self._attributes['value'] = (
                     live_result.get('result', {}).get('result', {}).get('value', text)
                 )
-            except Exception:
+            except (
+                KeyError,
+                TypeError,
+                AttributeError,
+                CommandExecutionTimeout,
+                WebSocketConnectionClosed,
+            ):
                 self._attributes['value'] = text
 
     async def set_input_files(self, files: str | Path | list[str | Path]):

--- a/pydoll/elements/web_element.py
+++ b/pydoll/elements/web_element.py
@@ -690,9 +690,7 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
             # insertText appends at cursor, so the result may differ from
             # the inserted text when the field already had content.
             try:
-                live_result = await self.execute_script(
-                    'return this.value', return_by_value=True
-                )
+                live_result = await self.execute_script('return this.value', return_by_value=True)
                 self._attributes['value'] = (
                     live_result.get('result', {}).get('result', {}).get('value', text)
                 )

--- a/pydoll/interactions/iframe.py
+++ b/pydoll/interactions/iframe.py
@@ -31,6 +31,12 @@ class IFrameContext:
     session_handler: Optional[ConnectionHandler] = None
     session_id: Optional[str] = None
 
+    async def close(self) -> None:
+        """Close the session handler if one was created for this context."""
+        if self.session_handler is not None:
+            await self.session_handler.close()
+            self.session_handler = None
+
 
 class IFrameContextResolver:
     """Resolves iframe context for WebElement."""
@@ -251,7 +257,7 @@ class IFrameContextResolver:
             current_document_url or resolved_url,
         )
 
-    async def _resolve_oopif_by_parent(
+    async def _resolve_oopif_by_parent(  # noqa: PLR0912
         self,
         content_frame_id: str,
         backend_node_id: Optional[int],
@@ -274,51 +280,42 @@ class IFrameContextResolver:
         browser_handler = ConnectionHandler(
             connection_port=self._element._connection_handler._connection_port
         )
-        targets_response: GetTargetsResponse = await browser_handler.execute_command(
-            TargetCommands.get_targets()
-        )
-        target_infos = targets_response.get('result', {}).get('targetInfos', [])
-
-        # The handler/session that can resolve DOM.getFrameOwner for the
-        # element's context.  When the <iframe> lives inside a nested OOPIF
-        # the Tab-level handler has no visibility; we must route through the
-        # session that originally found the element.
-        owner_handler = base_handler or self._element._connection_handler
-        owner_session_id = base_session_id
-
-        direct_children = [
-            target_info
-            for target_info in target_infos
-            if target_info.get('type') in {'iframe', 'page'}
-            and target_info.get('parentFrameId') == content_frame_id
-        ]
-
-        is_single_child = len(direct_children) == 1
-        for child_target in direct_children:
-            attach_response: AttachToTargetResponse = await browser_handler.execute_command(
-                TargetCommands.attach_to_target(target_id=child_target['targetId'], flatten=True)
+        try:
+            targets_response: GetTargetsResponse = await browser_handler.execute_command(
+                TargetCommands.get_targets()
             )
-            attached_session_id = attach_response.get('result', {}).get('sessionId')
-            if not attached_session_id:
-                continue
+            target_infos = targets_response.get('result', {}).get('targetInfos', [])
 
-            frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
-            root_frame = (frame_tree or {}).get('frame', {})
-            root_frame_id = root_frame.get('id', '')
+            # The handler/session that can resolve DOM.getFrameOwner for the
+            # element's context.  When the <iframe> lives inside a nested OOPIF
+            # the Tab-level handler has no visibility; we must route through the
+            # session that originally found the element.
+            owner_handler = base_handler or self._element._connection_handler
+            owner_session_id = base_session_id
 
-            if is_single_child and root_frame_id and backend_node_id is None:
-                return (
-                    browser_handler,
-                    attached_session_id,
-                    root_frame_id,
-                    root_frame.get('url'),
+            direct_children = [
+                target_info
+                for target_info in target_infos
+                if target_info.get('type') in {'iframe', 'page'}
+                and target_info.get('parentFrameId') == content_frame_id
+            ]
+
+            is_single_child = len(direct_children) == 1
+            for child_target in direct_children:
+                attach_response: AttachToTargetResponse = await browser_handler.execute_command(
+                    TargetCommands.attach_to_target(
+                        target_id=child_target['targetId'], flatten=True
+                    )
                 )
+                attached_session_id = attach_response.get('result', {}).get('sessionId')
+                if not attached_session_id:
+                    continue
 
-            if root_frame_id and backend_node_id is not None:
-                owner_backend_id = await self._owner_backend_for(
-                    owner_handler, owner_session_id, root_frame_id
-                )
-                if owner_backend_id == backend_node_id:
+                frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
+                root_frame = (frame_tree or {}).get('frame', {})
+                root_frame_id = root_frame.get('id', '')
+
+                if is_single_child and root_frame_id and backend_node_id is None:
                     return (
                         browser_handler,
                         attached_session_id,
@@ -326,39 +323,39 @@ class IFrameContextResolver:
                         root_frame.get('url'),
                     )
 
-        for target_info in target_infos:
-            if target_info.get('type') not in {'iframe', 'page'}:
-                continue
-            attach_response = await browser_handler.execute_command(
-                TargetCommands.attach_to_target(
-                    target_id=target_info.get('targetId', ''), flatten=True
-                )
-            )
-            attached_session_id = attach_response.get('result', {}).get('sessionId')
-            if not attached_session_id:
-                continue
+                if root_frame_id and backend_node_id is not None:
+                    owner_backend_id = await self._owner_backend_for(
+                        owner_handler, owner_session_id, root_frame_id
+                    )
+                    if owner_backend_id == backend_node_id:
+                        return (
+                            browser_handler,
+                            attached_session_id,
+                            root_frame_id,
+                            root_frame.get('url'),
+                        )
 
-            frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
-            root_frame = (frame_tree or {}).get('frame', {})
-            root_frame_id = root_frame.get('id', '')
-
-            # Direct match: the <iframe> element's frameId (content_frame_id)
-            # equals this target's root frame ID.  This handles nested OOPIFs
-            # where DOM.getFrameOwner cannot be resolved through the main
-            # page handler.
-            if root_frame_id and root_frame_id == content_frame_id:
-                return (
-                    browser_handler,
-                    attached_session_id,
-                    root_frame_id,
-                    root_frame.get('url'),
+            for target_info in target_infos:
+                if target_info.get('type') not in {'iframe', 'page'}:
+                    continue
+                attach_response = await browser_handler.execute_command(
+                    TargetCommands.attach_to_target(
+                        target_id=target_info.get('targetId', ''), flatten=True
+                    )
                 )
+                attached_session_id = attach_response.get('result', {}).get('sessionId')
+                if not attached_session_id:
+                    continue
 
-            if root_frame_id and backend_node_id is not None:
-                owner_backend_id = await self._owner_backend_for(
-                    owner_handler, owner_session_id, root_frame_id
-                )
-                if owner_backend_id == backend_node_id:
+                frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
+                root_frame = (frame_tree or {}).get('frame', {})
+                root_frame_id = root_frame.get('id', '')
+
+                # Direct match: the <iframe> element's frameId (content_frame_id)
+                # equals this target's root frame ID.  This handles nested OOPIFs
+                # where DOM.getFrameOwner cannot be resolved through the main
+                # page handler.
+                if root_frame_id and root_frame_id == content_frame_id:
                     return (
                         browser_handler,
                         attached_session_id,
@@ -366,11 +363,27 @@ class IFrameContextResolver:
                         root_frame.get('url'),
                     )
 
-            child_frame_id = self._find_child_by_parent(frame_tree, content_frame_id)
-            if child_frame_id:
-                return browser_handler, attached_session_id, child_frame_id, None
+                if root_frame_id and backend_node_id is not None:
+                    owner_backend_id = await self._owner_backend_for(
+                        owner_handler, owner_session_id, root_frame_id
+                    )
+                    if owner_backend_id == backend_node_id:
+                        return (
+                            browser_handler,
+                            attached_session_id,
+                            root_frame_id,
+                            root_frame.get('url'),
+                        )
 
-        return None, None, None, None
+                child_frame_id = self._find_child_by_parent(frame_tree, content_frame_id)
+                if child_frame_id:
+                    return browser_handler, attached_session_id, child_frame_id, None
+
+            await browser_handler.close()
+            return None, None, None, None
+        except Exception:
+            await browser_handler.close()
+            raise
 
     @staticmethod
     def _find_child_by_parent(tree: FrameTree, parent_id: str) -> Optional[str]:

--- a/pydoll/interactions/iframe.py
+++ b/pydoll/interactions/iframe.py
@@ -242,13 +242,16 @@ class IFrameContextResolver:
             content_frame_id, backend_node_id, base_handler, base_session_id
         )
 
-        if session_handler and session_id and resolved_url:
+        if session_handler and session_id:
             return (
                 session_handler,
                 session_id,
                 resolved_frame_id or current_frame_id,
                 resolved_url or current_document_url,
             )
+
+        if session_handler:
+            await session_handler.close()
 
         return (
             None,

--- a/pydoll/interactions/iframe.py
+++ b/pydoll/interactions/iframe.py
@@ -257,7 +257,7 @@ class IFrameContextResolver:
             current_document_url or resolved_url,
         )
 
-    async def _resolve_oopif_by_parent(  # noqa: PLR0912
+    async def _resolve_oopif_by_parent(
         self,
         content_frame_id: str,
         backend_node_id: Optional[int],
@@ -281,109 +281,124 @@ class IFrameContextResolver:
             connection_port=self._element._connection_handler._connection_port
         )
         try:
-            targets_response: GetTargetsResponse = await browser_handler.execute_command(
-                TargetCommands.get_targets()
+            return await self._try_resolve_oopif(
+                browser_handler,
+                content_frame_id,
+                backend_node_id,
+                base_handler,
+                base_session_id,
             )
-            target_infos = targets_response.get('result', {}).get('targetInfos', [])
-
-            # The handler/session that can resolve DOM.getFrameOwner for the
-            # element's context.  When the <iframe> lives inside a nested OOPIF
-            # the Tab-level handler has no visibility; we must route through the
-            # session that originally found the element.
-            owner_handler = base_handler or self._element._connection_handler
-            owner_session_id = base_session_id
-
-            direct_children = [
-                target_info
-                for target_info in target_infos
-                if target_info.get('type') in {'iframe', 'page'}
-                and target_info.get('parentFrameId') == content_frame_id
-            ]
-
-            is_single_child = len(direct_children) == 1
-            for child_target in direct_children:
-                attach_response: AttachToTargetResponse = await browser_handler.execute_command(
-                    TargetCommands.attach_to_target(
-                        target_id=child_target['targetId'], flatten=True
-                    )
-                )
-                attached_session_id = attach_response.get('result', {}).get('sessionId')
-                if not attached_session_id:
-                    continue
-
-                frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
-                root_frame = (frame_tree or {}).get('frame', {})
-                root_frame_id = root_frame.get('id', '')
-
-                if is_single_child and root_frame_id and backend_node_id is None:
-                    return (
-                        browser_handler,
-                        attached_session_id,
-                        root_frame_id,
-                        root_frame.get('url'),
-                    )
-
-                if root_frame_id and backend_node_id is not None:
-                    owner_backend_id = await self._owner_backend_for(
-                        owner_handler, owner_session_id, root_frame_id
-                    )
-                    if owner_backend_id == backend_node_id:
-                        return (
-                            browser_handler,
-                            attached_session_id,
-                            root_frame_id,
-                            root_frame.get('url'),
-                        )
-
-            for target_info in target_infos:
-                if target_info.get('type') not in {'iframe', 'page'}:
-                    continue
-                attach_response = await browser_handler.execute_command(
-                    TargetCommands.attach_to_target(
-                        target_id=target_info.get('targetId', ''), flatten=True
-                    )
-                )
-                attached_session_id = attach_response.get('result', {}).get('sessionId')
-                if not attached_session_id:
-                    continue
-
-                frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
-                root_frame = (frame_tree or {}).get('frame', {})
-                root_frame_id = root_frame.get('id', '')
-
-                # Direct match: the <iframe> element's frameId (content_frame_id)
-                # equals this target's root frame ID.  This handles nested OOPIFs
-                # where DOM.getFrameOwner cannot be resolved through the main
-                # page handler.
-                if root_frame_id and root_frame_id == content_frame_id:
-                    return (
-                        browser_handler,
-                        attached_session_id,
-                        root_frame_id,
-                        root_frame.get('url'),
-                    )
-
-                if root_frame_id and backend_node_id is not None:
-                    owner_backend_id = await self._owner_backend_for(
-                        owner_handler, owner_session_id, root_frame_id
-                    )
-                    if owner_backend_id == backend_node_id:
-                        return (
-                            browser_handler,
-                            attached_session_id,
-                            root_frame_id,
-                            root_frame.get('url'),
-                        )
-
-                child_frame_id = self._find_child_by_parent(frame_tree, content_frame_id)
-                if child_frame_id:
-                    return browser_handler, attached_session_id, child_frame_id, None
-
-            await browser_handler.close()
-            return None, None, None, None
         except Exception:
             await browser_handler.close()
             raise
+
+    async def _try_resolve_oopif(
+        self,
+        browser_handler: ConnectionHandler,
+        content_frame_id: str,
+        backend_node_id: Optional[int],
+        base_handler: Optional[ConnectionHandler],
+        base_session_id: Optional[str],
+    ) -> tuple[Optional[ConnectionHandler], Optional[str], Optional[str], Optional[str]]:
+        """Core logic for OOPIF resolution. Caller owns the handler lifecycle."""
+        targets_response: GetTargetsResponse = await browser_handler.execute_command(
+            TargetCommands.get_targets()
+        )
+        target_infos = targets_response.get('result', {}).get('targetInfos', [])
+
+        # The handler/session that can resolve DOM.getFrameOwner for the
+        # element's context.  When the <iframe> lives inside a nested OOPIF
+        # the Tab-level handler has no visibility; we must route through the
+        # session that originally found the element.
+        owner_handler = base_handler or self._element._connection_handler
+        owner_session_id = base_session_id
+
+        direct_children = [
+            target_info
+            for target_info in target_infos
+            if target_info.get('type') in {'iframe', 'page'}
+            and target_info.get('parentFrameId') == content_frame_id
+        ]
+
+        is_single_child = len(direct_children) == 1
+        for child_target in direct_children:
+            attach_response: AttachToTargetResponse = await browser_handler.execute_command(
+                TargetCommands.attach_to_target(target_id=child_target['targetId'], flatten=True)
+            )
+            attached_session_id = attach_response.get('result', {}).get('sessionId')
+            if not attached_session_id:
+                continue
+
+            frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
+            root_frame = (frame_tree or {}).get('frame', {})
+            root_frame_id = root_frame.get('id', '')
+
+            if is_single_child and root_frame_id and backend_node_id is None:
+                return (
+                    browser_handler,
+                    attached_session_id,
+                    root_frame_id,
+                    root_frame.get('url'),
+                )
+
+            if root_frame_id and backend_node_id is not None:
+                owner_backend_id = await self._owner_backend_for(
+                    owner_handler, owner_session_id, root_frame_id
+                )
+                if owner_backend_id == backend_node_id:
+                    return (
+                        browser_handler,
+                        attached_session_id,
+                        root_frame_id,
+                        root_frame.get('url'),
+                    )
+
+        for target_info in target_infos:
+            if target_info.get('type') not in {'iframe', 'page'}:
+                continue
+            attach_response = await browser_handler.execute_command(
+                TargetCommands.attach_to_target(
+                    target_id=target_info.get('targetId', ''), flatten=True
+                )
+            )
+            attached_session_id = attach_response.get('result', {}).get('sessionId')
+            if not attached_session_id:
+                continue
+
+            frame_tree = await self._get_frame_tree_for(browser_handler, attached_session_id)
+            root_frame = (frame_tree or {}).get('frame', {})
+            root_frame_id = root_frame.get('id', '')
+
+            # Direct match: the <iframe> element's frameId (content_frame_id)
+            # equals this target's root frame ID.  This handles nested OOPIFs
+            # where DOM.getFrameOwner cannot be resolved through the main
+            # page handler.
+            if root_frame_id and root_frame_id == content_frame_id:
+                return (
+                    browser_handler,
+                    attached_session_id,
+                    root_frame_id,
+                    root_frame.get('url'),
+                )
+
+            if root_frame_id and backend_node_id is not None:
+                owner_backend_id = await self._owner_backend_for(
+                    owner_handler, owner_session_id, root_frame_id
+                )
+                if owner_backend_id == backend_node_id:
+                    return (
+                        browser_handler,
+                        attached_session_id,
+                        root_frame_id,
+                        root_frame.get('url'),
+                    )
+
+            child_frame_id = self._find_child_by_parent(frame_tree, content_frame_id)
+            if child_frame_id:
+                return browser_handler, attached_session_id, child_frame_id, None
+
+        await browser_handler.close()
+        return None, None, None, None
 
     @staticmethod
     def _find_child_by_parent(tree: FrameTree, parent_id: str) -> Optional[str]:

--- a/pydoll/interactions/iframe.py
+++ b/pydoll/interactions/iframe.py
@@ -242,7 +242,7 @@ class IFrameContextResolver:
             content_frame_id, backend_node_id, base_handler, base_session_id
         )
 
-        if session_handler and session_id:
+        if session_handler and session_id and resolved_url:
             return (
                 session_handler,
                 session_id,

--- a/pydoll/utils/bundle.py
+++ b/pydoll/utils/bundle.py
@@ -166,13 +166,20 @@ def rewrite_html_urls(
     html: str,
     asset_map: dict[str, tuple[str, bytes, str, ResourceType]],
 ) -> str:
-    """Rewrite asset URLs in HTML to point to local assets/ directory."""
+    """Rewrite asset URLs in HTML to point to local assets/ directory.
+
+    Handles both absolute URLs (https://...) and root-relative paths (/style.css)
+    by deriving the path component from each absolute URL and replacing it too.
+    """
     for url, (filename, data, mime, rtype) in asset_map.items():
         if rtype == ResourceType.STYLESHEET:
             css_text = data.decode('utf-8', errors='replace')
             rewritten_css = rewrite_css_urls(css_text, url, asset_map)
             asset_map[url] = (filename, rewritten_css.encode('utf-8'), mime, rtype)
         html = html.replace(url, f'assets/{filename}')
+        parsed = urlparse(url)
+        if parsed.path and parsed.path != '/':
+            html = html.replace(parsed.path, f'assets/{filename}')
     return html
 
 

--- a/pydoll/utils/bundle.py
+++ b/pydoll/utils/bundle.py
@@ -171,15 +171,22 @@ def rewrite_html_urls(
     Handles both absolute URLs (https://...) and root-relative paths (/style.css)
     by deriving the path component from each absolute URL and replacing it too.
     """
-    for url, (filename, data, mime, rtype) in asset_map.items():
+    replacements: dict[str, str] = {}
+    for url, (filename, data, mime, rtype) in list(asset_map.items()):
         if rtype == ResourceType.STYLESHEET:
             css_text = data.decode('utf-8', errors='replace')
             rewritten_css = rewrite_css_urls(css_text, url, asset_map)
             asset_map[url] = (filename, rewritten_css.encode('utf-8'), mime, rtype)
-        html = html.replace(url, f'assets/{filename}')
+
+        replacements[url] = f'assets/{filename}'
         parsed = urlparse(url)
         if parsed.path and parsed.path != '/':
-            html = html.replace(parsed.path, f'assets/{filename}')
+            replacements[parsed.path] = f'assets/{filename}'
+
+    # Apply longest-first to prevent shorter paths from corrupting longer ones.
+    for old_str in sorted(replacements, key=len, reverse=True):
+        html = html.replace(old_str, replacements[old_str])
+
     return html
 
 

--- a/pydoll/utils/general.py
+++ b/pydoll/utils/general.py
@@ -4,6 +4,7 @@ import os
 import re
 from html import unescape
 from html.parser import HTMLParser
+from pathlib import Path
 
 import aiohttp
 
@@ -140,6 +141,20 @@ async def get_browser_ws_address(port: int) -> str:
         raise InvalidResponse(f'Failed to get browser ws address: {e}')
 
 
+def _is_executable(path: str) -> bool:
+    """Check if a path points to an executable file.
+
+    On Windows, uses PATHEXT to validate the file extension.
+    On Unix, uses the execute permission bit.
+    """
+    if not os.path.isfile(path):
+        return False
+    if os.name == 'nt':
+        pathext = {ext.lower() for ext in os.environ.get('PATHEXT', '').split(os.pathsep)}
+        return Path(path).suffix.lower() in pathext
+    return os.access(path, os.X_OK)
+
+
 def validate_browser_paths(paths: list[str]) -> str:
     """
     Validates potential browser executable paths and returns the first valid one.
@@ -159,7 +174,7 @@ def validate_browser_paths(paths: list[str]) -> str:
         InvalidBrowserPath: If the browser executable is not found at the path.
     """
     for path in paths:
-        if os.path.isfile(path) and os.access(path, os.X_OK):
+        if _is_executable(path):
             return path
     raise InvalidBrowserPath(f'No valid browser path found in: {paths}')
 

--- a/tests/integration/pages/web_element.html
+++ b/tests/integration/pages/web_element.html
@@ -74,6 +74,9 @@
         <option value="y" id="opt-y">Y</option>
     </select>
 
+    <input id="number-input" type="number" value="42">
+    <input id="email-input" type="email" value="user@example.com">
+
     <div id="contents-only"><span>no box model here</span></div>
 
     <shadow-host id="shadow-host"></shadow-host>

--- a/tests/integration/test_tab_io_integration.py
+++ b/tests/integration/test_tab_io_integration.py
@@ -181,12 +181,6 @@ class TestSaveBundle:
         with pytest.raises(InvalidFileExtension):
             await tab.save_bundle(str(tmp_path / 'bundle.tar'))
 
-    @pytest.mark.xfail(
-        reason='BUG: rewrite_html_urls does a literal string replace of absolute resource '
-        'URLs, so relative/root-relative HTML asset refs are bundled but never rewritten, '
-        'leaving index.html pointing at the original (broken offline) URLs.',
-        strict=True,
-    )
     @pytest.mark.asyncio
     async def test_relative_html_urls_are_rewritten(self, relative_served_tab, tmp_path):
         tab, _ = relative_served_tab

--- a/tests/integration/test_web_element_integration.py
+++ b/tests/integration/test_web_element_integration.py
@@ -79,12 +79,6 @@ async def test_insert_text_and_clear_update_value(element_tab):
     assert await _live(field, 'this.value') == ''
 
 
-@pytest.mark.xfail(
-    reason='insert_text caches the inserted text as the whole value; on a non-empty '
-    'field the real DOM value is the existing text plus the insertion, so the '
-    'cached element.value diverges from the DOM',
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_insert_text_cached_value_matches_dom_on_nonempty_field(element_tab):
     field = await element_tab.find(id='text-input')

--- a/tests/integration/test_web_element_integration.py
+++ b/tests/integration/test_web_element_integration.py
@@ -419,3 +419,9 @@ async def test_insert_text_falls_back_to_append_when_selection_read_throws(eleme
     live = await _live(field, 'this.value')
     assert live == 'before after'
     assert field.value == 'before after'
+
+    # Empty text should clear the field, not leave it unchanged
+    await field.insert_text('')
+    live = await _live(field, 'this.value')
+    assert live == ''
+    assert field.value == ''

--- a/tests/integration/test_web_element_integration.py
+++ b/tests/integration/test_web_element_integration.py
@@ -330,3 +330,92 @@ async def test_bounds_raises_key_error_for_element_without_box_model(element_tab
     contents_only = await element_tab.find(id='contents-only')
     with pytest.raises(KeyError):
         await contents_only.bounds
+
+
+# --- insert_text on input types where selectionStart/selectionEnd throw ---
+
+
+@pytest.mark.asyncio
+async def test_insert_text_on_number_input_does_not_raise(element_tab):
+    """type=number inputs throw InvalidStateError on selectionStart/selectionEnd.
+
+    The guarded INSERT_TEXT JS must catch this and still update the value.
+    """
+    field = await element_tab.find(id='number-input')
+    await field.insert_text('99')
+    assert await _live(field, 'this.value') == '4299'
+    assert field.value == '4299'
+
+
+@pytest.mark.asyncio
+async def test_insert_text_on_email_input_does_not_raise(element_tab):
+    """type=email inputs also lack selection APIs in some browsers."""
+    field = await element_tab.find(id='email-input')
+    await field.insert_text('+tag')
+    assert await _live(field, 'this.value') == 'user@example.com+tag'
+    assert field.value == 'user@example.com+tag'
+
+
+@pytest.mark.asyncio
+async def test_insert_text_on_text_input_still_restores_selection(element_tab):
+    """Normal text inputs must continue to support selection restoration."""
+    field = await element_tab.find(id='text-input')
+    await field.clear()
+    await field.insert_text('hello')
+    # Place cursor in the middle, then insert
+    await field.execute_script(
+        "this.selectionStart = this.selectionEnd = 2; return null",
+        return_by_value=True,
+    )
+    await field.insert_text('XY')
+    live = await _live(field, 'this.value')
+    assert live == 'heXYllo'
+    assert field.value == 'heXYllo'
+
+
+@pytest.mark.asyncio
+async def test_insert_text_empty_on_number_input_clears_via_select_all(element_tab):
+    """Empty insert on a non-selectable input still runs the select-all path.
+
+    el.select() is a no-op on number inputs, so start=0/end=length causes
+    the value to be replaced with '' (before='' + text='' + after='').
+    """
+    field = await element_tab.find(id='number-input')
+    # Reset to known value via JS directly (can't clear() on number input)
+    await field.execute_script("this.value = '7'", return_by_value=True)
+    await field.insert_text('')
+    live = await _live(field, 'this.value')
+    assert live == ''
+    assert field.value == ''
+
+
+@pytest.mark.asyncio
+async def test_insert_text_falls_back_to_append_when_selection_read_throws(element_tab):
+    """Simulate browsers that throw on reading selectionStart/selectionEnd.
+
+    Chromium returns null for non-selectable inputs, but some browsers (e.g.
+    Firefox) throw InvalidStateError on the read. Shadow the getters to throw,
+    then verify insert_text falls back to the append-only path (first catch
+    block, constants.py lines 414-419).
+    """
+    field = await element_tab.find(id='text-input')
+    await field.clear()
+    await field.execute_script("this.value = 'before'", return_by_value=True)
+
+    # Shadow selectionStart/selectionEnd with throwing getters
+    await field.execute_script(r"""
+        Object.defineProperty(this, 'selectionStart', {
+            get: function() { throw new DOMException('no selection', 'InvalidStateError'); },
+            configurable: true
+        });
+        Object.defineProperty(this, 'selectionEnd', {
+            get: function() { throw new DOMException('no selection', 'InvalidStateError'); },
+            configurable: true
+        });
+    """)
+
+    await field.insert_text(' after')
+
+    live = await _live(field, 'this.value')
+    assert live == 'before after'
+    assert field.value == 'before after'

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,8 @@ import sys
 from unittest.mock import patch
 
 from pydoll import exceptions
+
+_EXE = '.exe' if os.name == 'nt' else ''
 from pydoll.utils import (
     clean_script_for_analysis,
     decode_base64_to_bytes,
@@ -157,7 +159,7 @@ class TestUtils:
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a temporary executable file
-            valid_path = os.path.join(temp_dir, 'browser')
+            valid_path = os.path.join(temp_dir, f'browser{_EXE}')
             with open(valid_path, 'w') as f:
                 f.write('#!/bin/bash\necho "browser"')
             os.chmod(valid_path, 0o755)  # Make it executable
@@ -175,8 +177,8 @@ class TestUtils:
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create two valid executable files
-            first_valid = os.path.join(temp_dir, 'browser1')
-            second_valid = os.path.join(temp_dir, 'browser2')
+            first_valid = os.path.join(temp_dir, f'browser1{_EXE}')
+            second_valid = os.path.join(temp_dir, f'browser2{_EXE}')
             
             for path in [first_valid, second_valid]:
                 with open(path, 'w') as f:
@@ -247,11 +249,11 @@ class TestUtils:
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create one valid executable
-            valid_path = os.path.join(temp_dir, 'browser')
+            valid_path = os.path.join(temp_dir, f'browser{_EXE}')
             with open(valid_path, 'w') as f:
                 f.write('#!/bin/bash\necho "browser"')
             os.chmod(valid_path, 0o755)
-            
+
             # Mix valid and invalid paths
             paths = [
                 '/nonexistent/browser1',
@@ -285,7 +287,7 @@ class TestValidateBrowserPaths:
     def test_validate_browser_paths_valid_path(self, tmp_path):
         """Test with valid executable path."""
         # Create a temporary executable file
-        executable = tmp_path / "browser"
+        executable = tmp_path / f"browser{_EXE}"
         executable.write_text("#!/bin/bash\necho 'browser'")
         executable.chmod(0o755)
         

--- a/tests/unit/test_web_element.py
+++ b/tests/unit/test_web_element.py
@@ -134,7 +134,19 @@ async def test_clear_raises_when_element_rejects_input(fake_conn, make_element):
 @pytest.mark.asyncio
 async def test_insert_text_updates_cached_value(fake_conn, make_element):
     element = make_element(attributes=['tag_name', 'input'])
-    fake_conn.set_response('Runtime.callFunctionOn', {'result': {'value': True}})
+    # insert_text makes two Runtime.callFunctionOn calls:
+    # 1. INSERT_TEXT script → returns True (success)
+    # 2. read this.value → returns the actual DOM value
+    call_count = 0
+
+    async def patched_execute(command, timeout=60):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {'id': 1, 'result': {'result': {'type': 'boolean', 'value': True}}}
+        return {'id': 2, 'result': {'result': {'type': 'string', 'value': 'hello'}}}
+
+    fake_conn.execute_command = patched_execute
     await element.insert_text('hello')
     assert element.value == 'hello'
 

--- a/tests/unit/test_web_element.py
+++ b/tests/unit/test_web_element.py
@@ -152,6 +152,24 @@ async def test_insert_text_updates_cached_value(fake_conn, make_element):
 
 
 @pytest.mark.asyncio
+async def test_insert_text_cache_falls_back_when_reread_fails(fake_conn, make_element):
+    """When the re-read of this.value fails, the except block sets value = text."""
+    element = make_element(attributes=['tag_name', 'input'])
+    call_count = 0
+
+    async def patched_execute(command, timeout=60):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {'id': 1, 'result': {'result': {'type': 'boolean', 'value': True}}}
+        raise KeyError('result')
+
+    fake_conn.execute_command = patched_execute
+    await element.insert_text('fallback')
+    assert element.value == 'fallback'
+
+
+@pytest.mark.asyncio
 async def test_insert_text_raises_when_element_rejects_input(fake_conn, make_element):
     element = make_element(attributes=['tag_name', 'div'])
     fake_conn.set_response('Runtime.callFunctionOn', {'result': {'value': False}})


### PR DESCRIPTION
## Description
Addresses multiple bugs and maintenance issues found across the codebase: resource leaks in connection handlers, incorrect behavior in element caching and URL rewriting, platform compatibility issues, and async deprecation warnings.

## Related Issue(s)

Closes #426

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, no API changes)
- [x] Tests (adding missing tests or correcting existing tests)

## How Has This Been Tested?
Ran the full unit test suite and linter:

```bash
poetry run ruff check pydoll/ tests/
poetry run pytest tests/unit/ -q
```

All 410 tests pass, 2 skipped (Windows-only). Linter clean.

## Testing Checklist
- [x] Unit tests added/updated
- [x] All existing tests pass

## Implementation Details

**Resource leaks:**
- `_collect_oopif_shadow_roots` (tab.py) — ConnectionHandler created on every call but never closed. Wrapped in `try/finally`.
- `_resolve_oopif_by_parent` (iframe.py) — Same pattern, handler leaked on error and no-match paths. Wrapped in `try/except` with cleanup. Added `IFrameContext.close()` for lifecycle management.

**Correctness fixes:**
- `Browser.connect()` (base.py) — `tabs[0]` with no guard raised raw `IndexError`. Now raises `NoValidTabFound`.
- `Browser.__aexit__` (base.py) — `shutil.copy2` called with potentially `None` path from `_get_user_data_dir()`. Added guard.
- `rewrite_html_urls` (bundle.py) — Only matched absolute URLs. Root-relative paths like `/style.css` were bundled but never rewritten. Now derives path via `urlparse` and rewrites those too.
- `WebElement.value` cache (web_element.py) — `insert_text()` cached only the inserted text. On pre-populated fields, DOM value is `existing + inserted`. Now re-reads DOM value to keep cache consistent.
- Docstring (decorators.py) — Referenced `@retry_on_exception(` but the decorator is `@retry(`.

**Platform compatibility:**
- `validate_browser_paths` (general.py) — Used `os.access(path, os.X_OK)` which is meaningless on NTFS. Now uses `PATHEXT` extension validation on Windows, `os.X_OK` on Unix.

**Deprecation:**
- `asyncio.get_event_loop()` (14 sites) — Replaced with `get_running_loop()` across `tab.py`, `connection_handler.py`, `web_element.py`, `find_elements_mixin.py`. Deprecated since 3.10, warns in 3.12+.

**Tests:**
- Removed `xfail` markers from two tests that now pass.
- Updated mocks for the new DOM re-read behavior in `insert_text`.
- Updated `validate_browser_paths` tests to use platform-appropriate extensions.

**Examples:**
- `cloudflare_bypass.py` — `get_page()` → `new_tab()` (method was renamed in a prior refactor).

## API Changes
None. All changes are internal fixes with no public API modifications.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `poetry run ruff check pydoll/ tests/` and fixed any issues
- [x] I have run `poetry run pytest tests/unit/ -q` and all tests pass
- [x] My commits follow the [conventional commits](https://www.conventionalcommits.org/) style


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser/tab connection behavior when no valid tabs are available, including safer state restoration.
  * Strengthened iframe/OOPIF session cleanup to ensure temporary resources are reliably closed.
  * Made wait/shadow-root/download timeout timing consistent.
  * Enhanced `insert_text` for `input`/`textarea`, including cached value reconciliation, selection handling, and clearing empty inserts.
  * Improved HTML asset/URL rewriting to prevent partial-path collisions; enhanced Windows executable detection.
  * Updated iframe contexts to support async closing.
* **Documentation**
  * Refreshed the retry decorator usage example.
* **Tests**
  * Enabled previously xfailed integration tests and added more `insert_text` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->