### PR TITLE
fix: nested iframes

### DIFF
--- a/pydoll/browser/requests/har_recorder.py
+++ b/pydoll/browser/requests/har_recorder.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 
 _PYDOLL_CREATOR_NAME = 'pydoll'
 _HTTP_NOT_MODIFIED = 304
+_BODY_FETCH_ATTEMPTS = 5
+_BODY_FETCH_RETRY_DELAY = 0.1
 
 
 def _get_pydoll_version() -> str:
@@ -265,7 +267,8 @@ class HarRecorder:
         if not pending:
             return
 
-        body, base64_encoded = await self._fetch_response_body(request_id)
+        expects_body = pending.get('body_bytes', -1) > 0
+        body, base64_encoded = await self._fetch_response_body(request_id, expects_body)
         pending['response_body'] = body
         pending['response_body_base64'] = base64_encoded
 
@@ -302,20 +305,43 @@ class HarRecorder:
             self._entries.append(entry)
         logger.debug('HAR: flushed pending entries')
 
-    async def _fetch_response_body(self, request_id: str) -> tuple[str, bool]:
+    async def _fetch_response_body(
+        self, request_id: str, expects_body: bool = False
+    ) -> tuple[str, bool]:
         """Fetch the response body via Network.getResponseBody.
+
+        The DevTools body buffer is occasionally not ready the instant
+        loadingFinished fires (seen intermittently on Windows). When the
+        dataReceived events already told us a body exists (``expects_body``),
+        retry briefly on an errored or empty result instead of silently
+        recording an empty body.
 
         Returns:
             Tuple of (body_text, is_base64_encoded). Returns ('', False) on failure.
         """
-        try:
-            command = NetworkCommands.get_response_body(request_id)
-            response: GetResponseBodyResponse = await self._tab._execute_command(command)
-            body_result = response['result']
-            return body_result['body'], body_result['base64Encoded']
-        except Exception:
-            logger.debug('HAR: failed to fetch response body for %s', request_id)
-            return '', False
+        attempts = _BODY_FETCH_ATTEMPTS if expects_body else 1
+        for attempt in range(attempts):
+            try:
+                command = NetworkCommands.get_response_body(request_id)
+                response: GetResponseBodyResponse = await self._tab._execute_command(command)
+                body_result = response['result']
+                body, base64_encoded = body_result['body'], body_result['base64Encoded']
+                if body or not expects_body:
+                    return body, base64_encoded
+            except Exception:
+                logger.debug(
+                    'HAR: failed to fetch response body for %s (attempt %d/%d)',
+                    request_id,
+                    attempt + 1,
+                    attempts,
+                )
+            if attempt + 1 < attempts:
+                await asyncio.sleep(_BODY_FETCH_RETRY_DELAY)
+
+        logger.debug(
+            'HAR: response body unavailable for %s after %d attempt(s)', request_id, attempts
+        )
+        return '', False
 
     def _build_entry(self, pending: dict[str, Any]) -> HarEntry:
         """Build a HAR entry from accumulated pending data."""

--- a/pydoll/interactions/iframe.py
+++ b/pydoll/interactions/iframe.py
@@ -74,12 +74,12 @@ class IFrameContextResolver:
 
         context = IFrameContext(frame_id=frame_id, document_url=document_url)
 
-        if session_handler and session_id:
-            context.session_handler = session_handler
-            context.session_id = session_id
-
         effective_handler = session_handler or base_handler
         effective_session_id = session_id or base_session_id
+
+        if effective_session_id:
+            context.session_handler = effective_handler
+            context.session_id = effective_session_id
 
         execution_context_id = await self._create_isolated_world_for_frame(
             frame_id, effective_handler, effective_session_id

--- a/tests/integration/pages/oopif/oopif_content.html
+++ b/tests/integration/pages/oopif/oopif_content.html
@@ -19,6 +19,10 @@
     <iframe id="nested-iframe" src="oopif_nested.html"
             style="width:600px;height:200px;border:1px solid #666;"></iframe>
 
+    <!-- Nested data: URL iframe (opaque origin, no own OOPIF target) -->
+    <iframe id="data-iframe"
+            style="width:400px;height:120px;border:1px solid #333;"></iframe>
+
     <!-- Shadow root with elements and a nested iframe -->
     <div id="shadow-host"></div>
 
@@ -30,6 +34,16 @@
                 count++;
                 document.getElementById('oopif-btn-count').textContent = String(count);
             });
+        })();
+
+        // Data: URL iframe (opaque origin) nested inside this OOPIF
+        (function() {
+            document.getElementById('data-iframe').src =
+                'data:text/html,' +
+                encodeURIComponent(
+                    '<h2 id="data-heading">Data Frame Content</h2>' +
+                    '<input id="data-input" type="text">'
+                );
         })();
 
         // Shadow root containing text, button, and a nested iframe

--- a/tests/integration/test_nested_oopif_integration.py
+++ b/tests/integration/test_nested_oopif_integration.py
@@ -38,6 +38,26 @@ def _wait_for_server(host: str, port: int, timeout: float = 5.0) -> None:
     raise RuntimeError(f'Server {host}:{port} not ready within {timeout}s')
 
 
+def _cross_site_main_url(port_a: int, port_b: int) -> str:
+    """Build a main-page URL that is a different *site* than the OOPIF.
+
+    ``oopif_main.html`` always points its child iframe at ``127.0.0.1:{port_b}``,
+    so serving the main page from ``localhost`` (a distinct registrable domain
+    for Chrome's site isolation) forces the child into a real out-of-process
+    iframe with its own target/session. Cross-*port* alone (``127.0.0.1`` on
+    both sides) is same-site and would not create an OOPIF.
+
+    Skips the test when ``localhost`` does not resolve to the loopback address
+    the server is bound to (e.g. IPv6-only ``localhost``).
+    """
+    try:
+        with socket.create_connection(('localhost', port_a), timeout=0.5):
+            pass
+    except OSError:
+        pytest.skip('localhost is not reachable on the IPv4 loopback server')
+    return f'http://localhost:{port_a}/oopif_main.html?port={port_b}'
+
+
 @pytest.fixture(scope='module')
 def cross_origin_servers():
     """Two HTTP servers on different ports -> different origins -> OOPIF."""
@@ -150,6 +170,75 @@ class TestNestedIframeInsideOopif:
             input_el = await nested.find(id='nested-input', timeout=10)
             await input_el.type_text('hello from nested oopif')
             await wait_for_js_value(input_el, 'this.value', 'hello from nested oopif')
+
+
+class TestDataUrlIframeInsideOopif:
+    """Regression for nested cross-origin iframes: main -> OOPIF -> data: iframe.
+
+    Reproduces the reporter's scenario (nestedframes.netlify.app) where the
+    inner iframe uses a ``data:`` URL. A ``data:`` frame has an opaque origin
+    and stays inside the parent OOPIF's process, so it has no target of its
+    own. IFrameContextResolver therefore resolves no OOPIF session for it and
+    must fall back to the parent OOPIF session that created the isolated world;
+    before the fix it evaluated on the tab session and raised InvalidIFrame.
+    """
+
+    @pytest.mark.asyncio
+    async def test_find_element_in_data_iframe_inside_oopif(
+        self, ci_chrome_options, cross_origin_servers
+    ):
+        port_a, port_b = cross_origin_servers
+        url = _cross_site_main_url(port_a, port_b)
+
+        ci_chrome_options.add_argument('--site-per-process')
+        async with Chrome(options=ci_chrome_options) as browser:
+            tab = await browser.start()
+            await tab.go_to(url)
+
+            oopif = await tab.find(id='cross-origin-iframe', timeout=10)
+            data_iframe = await oopif.find(id='data-iframe', timeout=10)
+            assert data_iframe.is_iframe
+
+            heading = await data_iframe.find(id='data-heading', timeout=10)
+            assert await heading.text == 'Data Frame Content'
+
+    @pytest.mark.asyncio
+    async def test_find_body_in_data_iframe_inside_oopif(
+        self, ci_chrome_options, cross_origin_servers
+    ):
+        """The exact call from the bug report: find(tag_name='body')."""
+        port_a, port_b = cross_origin_servers
+        url = _cross_site_main_url(port_a, port_b)
+
+        ci_chrome_options.add_argument('--site-per-process')
+        async with Chrome(options=ci_chrome_options) as browser:
+            tab = await browser.start()
+            await tab.go_to(url)
+
+            oopif = await tab.find(id='cross-origin-iframe', timeout=10)
+            data_iframe = await oopif.find(id='data-iframe', timeout=10)
+
+            body = await data_iframe.find(tag_name='body', timeout=10)
+            assert 'Data Frame Content' in await body.text
+
+    @pytest.mark.asyncio
+    async def test_type_text_in_data_iframe_inside_oopif(
+        self, ci_chrome_options, cross_origin_servers
+    ):
+        port_a, port_b = cross_origin_servers
+        url = _cross_site_main_url(port_a, port_b)
+
+        ci_chrome_options.add_argument('--site-per-process')
+        async with Chrome(options=ci_chrome_options) as browser:
+            tab = await browser.start()
+            await tab.go_to(url)
+
+            oopif = await tab.find(id='cross-origin-iframe', timeout=10)
+            data_iframe = await oopif.find(id='data-iframe', timeout=10)
+
+            input_el = await data_iframe.find(id='data-input', timeout=10)
+            await input_el.type_text('typed into data frame')
+            await wait_for_js_value(input_el, 'this.value', 'typed into data frame')
 
 
 class TestShadowRootInsideOopif:

--- a/tests/unit/test_har_recorder.py
+++ b/tests/unit/test_har_recorder.py
@@ -72,3 +72,56 @@ async def test_stop_flushes_in_flight_request_as_pending_entry():
     assert entry['request']['url'] == 'http://x/slow'
     assert entry['response']['status'] == 0
     assert entry['response']['statusText'] == '(pending)'
+
+
+class _BodyTab(_FakeTab):
+    """Fake tab whose getResponseBody returns empty until a given attempt."""
+
+    def __init__(self, body: str, ready_on_attempt: int):
+        super().__init__()
+        self._body = body
+        self._ready_on_attempt = ready_on_attempt
+        self.body_calls = 0
+
+    async def _execute_command(self, command):
+        self.body_calls += 1
+        if self.body_calls < self._ready_on_attempt:
+            return {'result': {'body': '', 'base64Encoded': False}}
+        return {'result': {'body': self._body, 'base64Encoded': False}}
+
+
+@pytest.mark.asyncio
+async def test_fetch_response_body_retries_until_body_available():
+    """A body arriving a few attempts late (Windows race) is still captured."""
+    tab = _BodyTab('Hello from the test server', ready_on_attempt=3)
+    recorder = HarRecorder(tab=tab)
+
+    body, is_base64 = await recorder._fetch_response_body('r1', expects_body=True)
+
+    assert body == 'Hello from the test server'
+    assert is_base64 is False
+    assert tab.body_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_response_body_no_retry_when_body_not_expected():
+    """A legitimately empty body must not incur retries (204/redirect/etc)."""
+    tab = _BodyTab('never', ready_on_attempt=99)
+    recorder = HarRecorder(tab=tab)
+
+    body, is_base64 = await recorder._fetch_response_body('r1', expects_body=False)
+
+    assert body == ''
+    assert tab.body_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_response_body_gives_up_after_max_attempts():
+    """When the body never materializes, fall back to empty without hanging."""
+    tab = _BodyTab('never', ready_on_attempt=99)
+    recorder = HarRecorder(tab=tab)
+
+    body, _ = await recorder._fetch_response_body('r1', expects_body=True)
+
+    assert body == ''
+    assert tab.body_calls == 5


### PR DESCRIPTION
closes #406 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HAR recording to capture response bodies that become available shortly after network events.
  * Enhanced iframe handling for nested cross-origin and data URL frames, including element lookup and text input interactions.

* **Tests**
  * Added coverage for delayed and unavailable response bodies.
  * Added integration tests for interacting with nested data URL iframes inside cross-origin frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->