### PR TITLE
docs: render iframe tag safely in WebElement reference

### DIFF
--- a/pydoll/elements/web_element.py
+++ b/pydoll/elements/web_element.py
@@ -225,7 +225,7 @@ class WebElement(FindElementsMixin):  # noqa: PLR0904
     @property
     async def iframe_context(self) -> Optional[IFrameContext]:
         """
-        Return the resolved iframe context for this element when it is an <iframe>.
+        Return the resolved iframe context for this element when it is an ``<iframe>``.
 
         The context includes: frame_id, document_url, execution_context_id,
         document_object_id and, for OOPIF targets, the session_id and

--- a/tests/unit/test_web_element.py
+++ b/tests/unit/test_web_element.py
@@ -61,6 +61,12 @@ def test_is_iframe_reflects_tag_name(make_element):
     assert make_element(attributes=['tag_name', 'div']).is_iframe is False
 
 
+def test_iframe_context_docstring_escapes_iframe_tag():
+    docstring = WebElement.iframe_context.fget.__doc__
+    assert docstring is not None
+    assert '``<iframe>``' in docstring
+
+
 def test_attributes_returns_a_copy(make_element):
     element = make_element(attributes=['id', 'x'])
     snapshot = element.attributes


### PR DESCRIPTION
# Bug Fix Pull Request

## Related Issue(s)

Fixes #420

## Bug Description

The generated `WebElement` API page treats the tag named in the `iframe_context` description as a real iframe. The remaining method documentation is then parsed inside that element instead of continuing as normal page content.

## Root Cause

The source docstring contains a bare `<iframe>` tag. MkDocs preserves raw HTML in docstrings, and an iframe is not a self-closing element.

## Solution

Wrap `<iframe>` in the double-backtick code style already used by nearby Pydoll docstrings. MkDocs then emits escaped text inside a code element instead of a live iframe.

## Verification Steps

1. Build the documentation.
2. Open the generated `WebElement` API page.
3. Confirm `<iframe>` is displayed as code and the methods after `iframe_context` remain normal page content.

## Before / After

Before

```text
an <iframe>
```

After

```text
an ``<iframe>``
```

## Testing

- added a regression assertion for the `iframe_context` docstring
- compiled both changed Python files
- extracted the docstring through the Python AST and verified the raw tag is gone
- rendered the sentence with Pandoc and confirmed it becomes `<code>&lt;iframe&gt;</code>`
- ran `git diff --check`

The Poetry environment is not installed in this checkout, so the full lint and pytest tasks are left to repository CI.

## Testing Checklist

- [x] Added regression test that would have caught this bug
- [ ] Modified existing tests to account for this fix
- [ ] All tests pass
- [ ] Edge cases have been tested

## Impact

- [x] Low (isolated fix with no side effects)
- [ ] Medium (might affect closely related functionality)
- [ ] High (affects multiple areas or changes core behavior)

## Backwards Compatibility

- [x] This change is fully backward compatible
- [ ] This change introduces backward incompatibilities

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added test cases that prove my fix is effective
- [ ] I have run `poetry run task lint` and fixed any issues
- [ ] I have run `poetry run task test` and all tests pass
- [x] My commits follow the conventional commits style with a message explaining the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved inline formatting for the `<iframe>` reference in the element context documentation.

* **Tests**
  * Added coverage to verify the `<iframe>` markup is displayed correctly in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->