### PR TITLE
fix: preserve ws address when resolving iframe connections

### DIFF
--- a/pydoll/interactions/iframe.py
+++ b/pydoll/interactions/iframe.py
@@ -261,28 +261,19 @@ class IFrameContextResolver:
         )
 
     async def _resolve_oopif_by_parent(
-        self,
-        content_frame_id: str,
-        backend_node_id: Optional[int],
-        base_handler: Optional[ConnectionHandler] = None,
-        base_session_id: Optional[str] = None,
-    ) -> tuple[Optional[ConnectionHandler], Optional[str], Optional[str], Optional[str]]:
-        """Resolve out-of-process iframe using content frame id.
+            self,
+            content_frame_id: str,
+            backend_node_id: Optional[int],
+            base_handler: Optional[ConnectionHandler] = None,
+            base_session_id: Optional[str] = None,
+    ):
+        element_handler = self._element._connection_handler
 
-        ``content_frame_id`` is the frame ID of the frame *created* by the
-        ``<iframe>`` element (obtained from ``DOM.describeNode``'s
-        ``node.frameId``).  For OOPIF targets the root frame of the target
-        shares this ID, so we can match directly without needing
-        ``DOM.getFrameOwner``.
-
-        When a direct frame-ID match is not possible (e.g. nested sub-frames
-        inside the OOPIF), the method falls back to ``DOM.getFrameOwner``
-        using the routing handler/session that has DOM visibility into the
-        parent context.
-        """
         browser_handler = ConnectionHandler(
-            connection_port=self._element._connection_handler._connection_port
+            connection_port=element_handler._connection_port,
+            ws_address=element_handler._ws_address,
         )
+
         try:
             return await self._try_resolve_oopif(
                 browser_handler,


### PR DESCRIPTION
## Problem

When connecting Pydoll to an existing browser instance (for example, a browser started with nodriver), iframe child element resolution can lose the original WebSocket connection.

The issue occurs when a new ConnectionHandler is created without preserving the existing ws_address.

## Reproduction

1. Start Chrome externally with nodriver.
2. Get the browser websocket_url.
3. Connect Pydoll using Chrome.connect(ws_address).
4. Access elements inside an iframe.
5. The iframe resolution creates a new connection without the original WebSocket address.

## Change

Preserve the existing ws_address when creating the ConnectionHandler used for iframe resolution.

## Notes

I have not added a regression test yet. The issue appears specific to externally managed browser connections rather than browsers launched directly by Pydoll.

I simply do not have the time currently to implement this change in a safer way. I realize that it is failing tests. I'm hoping that some generous soul sees this and makes it work for the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iframe handling in scenarios where frames run in separate browser processes.
  * Increased connection reliability when resolving embedded frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->